### PR TITLE
Feature

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ tasks.compileKotlin {
     dependsOn("ktlintFormat")
     kotlinOptions {
         jvmTarget = "1.8"
+        allWarningsAsErrors = true
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.6.0") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
+    // 現状プロパティ名の変換はテストでしか使っていないのでtestImplementation
+    // https://mvnrepository.com/artifact/com.google.guava/guava
+    testImplementation(group = "com.google.guava", name = "guava", version = "28.2-jre")
 }
 
 tasks.compileKotlin {

--- a/src/main/kotlin/com/wrongwrong/mapk/core/CompanionKFunction.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/CompanionKFunction.kt
@@ -3,11 +3,17 @@ package com.wrongwrong.mapk.core
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.instanceParameter
+import kotlin.reflect.jvm.isAccessible
 
 internal class CompanionKFunction<T>(
     private val function: KFunction<T>,
     private val instance: Any
 ) : KFunction<T> by function {
+    init {
+        // このインスタンスを生成している時点でfunctionにアクセスしたい状況なので、アクセシビリティはここでセットする
+        function.isAccessible = true
+    }
+
     private val instanceParam by lazy { mapOf(function.instanceParameter!! to instance) }
 
     override val parameters: List<KParameter> by lazy {

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KFunctionWithInstance.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KFunctionWithInstance.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.full.instanceParameter
 import kotlin.reflect.jvm.isAccessible
 
-internal class CompanionKFunction<T>(
+internal class KFunctionWithInstance<T>(
     private val function: KFunction<T>,
     private val instance: Any
 ) : KFunction<T> by function {

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -117,11 +117,7 @@ internal fun <T : Any> getTarget(clazz: KClass<T>): KFunction<T> {
         clazz.companionObjectInstance?.let { companionObject ->
             companionObject::class.functions
                 .filter { it.annotations.any { annotation -> annotation is KConstructor } }
-                .map {
-                    // isAccessibleの書き換えはKotlinの都合で先に行う必要が有る
-                    it.isAccessible = true
-                    CompanionKFunction(it, companionObject) as KFunction<T>
-                }
+                .map { CompanionKFunction(it, companionObject) as KFunction<T> }
         } ?: emptyList()
 
     val constructors: List<KFunction<T>> = factoryConstructor + clazz.constructors

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -117,7 +117,7 @@ internal fun <T : Any> getTarget(clazz: KClass<T>): KFunction<T> {
         clazz.companionObjectInstance?.let { companionObject ->
             companionObject::class.functions
                 .filter { it.annotations.any { annotation -> annotation is KConstructor } }
-                .map { CompanionKFunction(it, companionObject) as KFunction<T> }
+                .map { KFunctionWithInstance(it, companionObject) as KFunction<T> }
         } ?: emptyList()
 
     val constructors: List<KFunction<T>> = factoryConstructor + clazz.constructors

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -39,6 +39,12 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
         }.let { function.callBy(it) }
     }
 
+    fun map(srcPair: Pair<String, Any?>): T = parameters
+        .single { it.name == srcPair.first }
+        .let {
+            function.callBy(mapOf(it.param to srcPair.second?.let { value -> mapObject(it, value) }))
+        }
+
     fun map(src: Any): T {
         val srcMap: Map<String, KProperty1.Getter<*, *>> =
             src::class.memberProperties.filterTargets().associate { property ->

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -5,7 +5,6 @@ import com.wrongwrong.mapk.annotations.KPropertyAlias
 import com.wrongwrong.mapk.annotations.KPropertyIgnore
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
-import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.companionObjectInstance
@@ -20,16 +19,12 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
         getTarget(clazz), propertyNameConverter
     )
 
-    private val parameters: Set<ParameterForMap<*>>
+    private val parameters: Set<ParameterForMap<*>> = function.parameters
+        .map { ParameterForMap.newInstance(it, propertyNameConverter) }
+        .toSet()
 
     init {
-        val params: List<KParameter> = function.parameters
-
-        if (params.isEmpty()) throw IllegalArgumentException("This function is not require arguments.")
-
-        parameters = params
-            .map { ParameterForMap.newInstance(it, propertyNameConverter) }
-            .toSet()
+        if (parameters.isEmpty()) throw IllegalArgumentException("This function is not require arguments.")
 
         // private関数に対してもマッピングできなければ何かと不都合があるため、accessibleは書き換える
         function.isAccessible = true

--- a/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
@@ -66,7 +66,7 @@ private fun <T : Any> creatorsFromCompanionObject(clazz: KClass<T>): Set<Pair<KC
         companionObject::class.functions
             .filter { it.annotations.any { annotation -> annotation is KConverter } }
             .map { function ->
-                val func: KFunction<T> = CompanionKFunction(function, companionObject) as KFunction<T>
+                val func: KFunction<T> = KFunctionWithInstance(function, companionObject) as KFunction<T>
 
                 (func.parameters.single().type.classifier as KClass<*>) to func
             }.toSet()

--- a/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
@@ -66,8 +66,6 @@ private fun <T : Any> creatorsFromCompanionObject(clazz: KClass<T>): Set<Pair<KC
         companionObject::class.functions
             .filter { it.annotations.any { annotation -> annotation is KConverter } }
             .map { function ->
-                // isAccessibleの書き換えはKotlinの都合で先に行う必要が有る
-                function.isAccessible = true
                 val func: KFunction<T> = CompanionKFunction(function, companionObject) as KFunction<T>
 
                 (func.parameters.single().type.classifier as KClass<*>) to func

--- a/src/test/kotlin/mapk/core/EnumMappingTest.kt
+++ b/src/test/kotlin/mapk/core/EnumMappingTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package mapk.core
 
 import com.wrongwrong.mapk.core.KMapper

--- a/src/test/kotlin/mapk/core/EnumMappingTest.kt
+++ b/src/test/kotlin/mapk/core/EnumMappingTest.kt
@@ -1,0 +1,26 @@
+package mapk.core
+
+import com.wrongwrong.mapk.core.KMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+enum class JvmLanguage {
+    Java, Scala, Groovy, Kotlin
+}
+
+private class EnumMappingDst(val language: JvmLanguage?)
+
+@DisplayName("文字列 -> Enumのマッピングテスト")
+class EnumMappingTest {
+    private val mapper = KMapper(EnumMappingDst::class)
+
+    @ParameterizedTest(name = "Non-Null要求")
+    @EnumSource(value = JvmLanguage::class)
+    fun test(language: JvmLanguage) {
+        val result = mapper.map("language" to language.name)
+
+        assertEquals(language, result.language)
+    }
+}

--- a/src/test/kotlin/mapk/core/PropertyNameConverterTest.kt
+++ b/src/test/kotlin/mapk/core/PropertyNameConverterTest.kt
@@ -1,0 +1,24 @@
+package mapk.core
+
+import com.google.common.base.CaseFormat
+import com.wrongwrong.mapk.core.KMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+private class CamelCaseDst(val camelCase: String)
+
+@DisplayName("プロパティ名変換のテスト")
+class PropertyNameConverterTest {
+    @Test
+    @DisplayName("スネークケースsrc -> キャメルケースdst")
+    fun test() {
+        val expected = "snakeCase"
+        val src = mapOf("camel_case" to expected)
+
+        val mapper = KMapper(CamelCaseDst::class) { CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it) }
+        val result = mapper.map(src)
+
+        assertEquals(expected, result.camelCase)
+    }
+}

--- a/src/test/kotlin/mapk/core/StringMappingTest.kt
+++ b/src/test/kotlin/mapk/core/StringMappingTest.kt
@@ -1,0 +1,17 @@
+package mapk.core
+
+import com.wrongwrong.mapk.core.KMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+private data class StringMappingDst(val value: String)
+
+@DisplayName("文字列に対してtoStringしたものを渡すテスト")
+class StringMappingTest {
+    @Test
+    fun test() {
+        val result: StringMappingDst = KMapper(StringMappingDst::class).map("value" to 1)
+        assertEquals("1", result.value)
+    }
+}


### PR DESCRIPTION
# 改善
- `Pair<String, Any?>`を引数にしたマッピングができるように修正
- 初期化時の処理を整理

# テスト追加
- 「文字列 -> `enum`」の変換処理
- 「`Any` -> 文字列」の変換処理
- マップ先プロパティ名の変換処理