### PR TITLE
 Improve processing time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class Dst(
 ### Set alias on map
 #### for getter
 ```kotlin
-class Src(@get:PropertyAlias("aliased") val str: String)
+class Src(@KGetterAlias("aliased") val str: String)
 
 class Dst(val aliased: String)
 ```
@@ -53,7 +53,7 @@ class Dst(val aliased: String)
 ```kotlin
 class Src(val str: String)
 
-class Dst(@param:PropertyAlias("str") private val _src: String) {
+class Dst(@param:KPropertyAlias("str") private val _src: String) {
   val src = _src.someArrangement
 }
 ```
@@ -64,7 +64,7 @@ val srcMap = mapOf("snake_case" to "SnakeCase")
 
 class Dst(val snakeCase: String)
 
-val dst: Dst = Mapper(DataClass::class.primaryConstructor!!) { it.toSnakeCase }.map(src)
+val dst: Dst = Mapper(::DataClass) { it.toSnakeCase }.map(src)
 ```
 
 ### Map param to another class
@@ -72,7 +72,7 @@ val dst: Dst = Mapper(DataClass::class.primaryConstructor!!) { it.toSnakeCase }.
 ```kotlin
 class CreatorClass @SingleArgCreator constructor(val arg: String) {
   companion object {
-    @SingleArgCreator
+    @KConverter
     fun fromInt(arg: Int): CreatorClass {
       return CreatorClass(arg.toString)
     }

--- a/src/main/kotlin/com/wrongwrong/mapk/annotations/KGetterAlias.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/annotations/KGetterAlias.kt
@@ -1,0 +1,5 @@
+package com.wrongwrong.mapk.annotations
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class KGetterAlias(val value: String)

--- a/src/main/kotlin/com/wrongwrong/mapk/annotations/KPropertyAlias.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/annotations/KPropertyAlias.kt
@@ -1,5 +1,5 @@
 package com.wrongwrong.mapk.annotations
 
-@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.PROPERTY_GETTER)
+@Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class KPropertyAlias(val value: String)

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KFunctionForCall.kt
@@ -1,0 +1,23 @@
+package com.wrongwrong.mapk.core
+
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.isAccessible
+
+class KFunctionForCall<T>(
+    private val function: KFunction<T>,
+    parameterSize: Int,
+    instance: Any? = null
+) {
+    private val originalArray: Array<Any?>
+    val argumentArray: Array<Any?> get() = originalArray.copyOf()
+
+    init {
+        // この関数には確実にアクセスするためアクセシビリティ書き換え
+        function.isAccessible = true
+
+        // 必要が有ればinstanceを先に、無ければ
+        originalArray = Array(parameterSize) { if (it == 0 && instance != null) instance else null }
+    }
+
+    fun call(arguments: Array<Any?>): T = function.call(*arguments)
+}

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KFunctionForCall.kt
@@ -1,23 +1,25 @@
 package com.wrongwrong.mapk.core
 
 import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
 import kotlin.reflect.jvm.isAccessible
 
-class KFunctionForCall<T>(
-    private val function: KFunction<T>,
-    parameterSize: Int,
-    instance: Any? = null
-) {
+class KFunctionForCall<T>(private val function: KFunction<T>, instance: Any? = null) {
+    val parameters: List<KParameter> = function.parameters
     private val originalArray: Array<Any?>
     val argumentArray: Array<Any?> get() = originalArray.copyOf()
 
     init {
         // この関数には確実にアクセスするためアクセシビリティ書き換え
         function.isAccessible = true
-
-        // 必要が有ればinstanceを先に、無ければ
-        originalArray = Array(parameterSize) { if (it == 0 && instance != null) instance else null }
+        originalArray = if (instance != null) {
+            Array(parameters.size) { if (it == 0) instance else null }
+        } else {
+            Array(parameters.size) { null }
+        }
     }
 
-    fun call(arguments: Array<Any?>): T = function.call(*arguments)
+    fun call(arguments: Array<Any?>): T {
+        return function.call(*arguments)
+    }
 }

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -51,9 +51,7 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
             src::class.memberProperties.filterTargets().associate { property ->
                 val getter = property.getAccessibleGetter()
 
-                val key = getter.findAnnotation<KPropertyAlias>()?.value ?: property.name
-
-                key to getter
+                (getter.findAnnotation<KPropertyAlias>()?.value ?: property.name) to getter
             }
 
         return parameters.associate {
@@ -76,9 +74,7 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
                         arg::class.memberProperties.filterTargets().associate { property ->
                             val getter = property.getAccessibleGetter()
 
-                            val key = getter.findAnnotation<KPropertyAlias>()?.value ?: property.name
-
-                            key to { getter.call(arg) }
+                            (getter.findAnnotation<KPropertyAlias>()?.value ?: property.name) to { getter.call(arg) }
                         }
                     }
                 }

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -24,6 +24,12 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
         .map { ParameterForMap.newInstance(it, propertyNameConverter) }
         .toSet()
 
+    private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters
+        .associate {
+            val param = ParameterForMap.newInstance(it, propertyNameConverter)
+            param.name to param
+        }
+
     init {
         if (parameters.isEmpty()) throw IllegalArgumentException("This function is not require arguments.")
 

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -38,12 +38,12 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
     }
 
     fun map(srcMap: Map<String, Any?>): T {
-        return parameters.associate {
-            // 取得した内容がnullでなければ適切にmapする
-            it.param to srcMap.getValue(it.name)?.let { value ->
-                mapObject(it, value)
+        return srcMap.entries.mapNotNull { (key, value) ->
+            parameterMap[key]?.let { param ->
+                // 取得した内容がnullでなければ適切にmapする
+                param.param to value?.let { mapObject(param, it) }
             }
-        }.let { function.callBy(it) }
+        }.let { function.callBy(it.toMap()) }
     }
 
     fun map(srcPair: Pair<String, Any?>): T = parameters

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -20,11 +20,10 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
         getTarget(clazz), propertyNameConverter
     )
 
-    private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters
-        .associate {
-            (it.findAnnotation<KPropertyAlias>()?.value ?: propertyNameConverter(it.name!!)) to
-                    ParameterForMap.newInstance(it)
-        }
+    private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters.associate {
+        (it.findAnnotation<KPropertyAlias>()?.value ?: propertyNameConverter(it.name!!)) to
+                ParameterForMap.newInstance(it)
+    }
 
     init {
         if (parameterMap.isEmpty()) throw IllegalArgumentException("This function is not require arguments.")

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -63,16 +63,22 @@ class KMapper<T : Any> private constructor(
         }
     }
 
+    private fun bindParameters(targetArray: Array<Any?>, srcPair: Pair<*, *>) {
+        parameterMap.getValue(srcPair.first.toString()).let {
+            targetArray[it.index] = srcPair.second?.let { value -> mapObject(it, value) }
+        }
+    }
+
     fun map(srcMap: Map<String, Any?>): T {
         val array: Array<Any?> = function.argumentArray
         srcMap.bindParameters(array)
         return function.call(array)
     }
 
-    fun map(srcPair: Pair<String, Any?>): T = parameterMap.getValue(srcPair.first).let {
+    fun map(srcPair: Pair<String, Any?>): T {
         val array: Array<Any?> = function.argumentArray
-        array[it.index] = srcPair.second?.let { value -> mapObject(it, value) }
-        function.call(array)
+        bindParameters(array, srcPair)
+        return function.call(array)
     }
 
     fun map(src: Any): T {
@@ -87,9 +93,7 @@ class KMapper<T : Any> private constructor(
         listOf(*args).forEach { arg ->
             when (arg) {
                 is Map<*, *> -> arg.bindParameters(array)
-                is Pair<*, *> -> parameterMap.getValue(arg.first as String).let {
-                    array[it.index] = arg.second?.let { value -> mapObject(it, value) }
-                }
+                is Pair<*, *> -> bindParameters(array, arg)
                 else -> arg::class.bindParameters(array, arg)
             }
         }

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -45,7 +45,7 @@ class KMapper<T : Any> private constructor(
         srcMap.forEach { (key, value) ->
             parameterMap[key]?.let { param ->
                 // 取得した内容がnullでなければ適切にmapする
-                array[param.param.index] = value?.let { mapObject(param, it) }
+                array[param.index] = value?.let { mapObject(param, it) }
             }
         }
 
@@ -54,7 +54,7 @@ class KMapper<T : Any> private constructor(
 
     fun map(srcPair: Pair<String, Any?>): T = parameterMap.getValue(srcPair.first).let {
         val array: Array<Any?> = function.argumentArray
-        array[it.param.index] = srcPair.second?.let { value -> mapObject(it, value) }
+        array[it.index] = srcPair.second?.let { value -> mapObject(it, value) }
         function.call(array)
     }
 
@@ -65,7 +65,7 @@ class KMapper<T : Any> private constructor(
             if (property.visibility == KVisibility.PUBLIC && property.annotations.none { annotation -> annotation is KPropertyIgnore }) {
                 val getter = property.getAccessibleGetter()
                 parameterMap[getter.findAnnotation<KPropertyAlias>()?.value ?: property.name]?.let {
-                    array[it.param.index] = getter.call(src)?.let { value -> mapObject(it, value) }
+                    array[it.index] = getter.call(src)?.let { value -> mapObject(it, value) }
                 }
             }
         }
@@ -81,17 +81,17 @@ class KMapper<T : Any> private constructor(
                 is Map<*, *> -> arg.forEach { (key, value) ->
                     parameterMap[key]?.let { param ->
                         // 取得した内容がnullでなければ適切にmapする
-                        array[param.param.index] = value?.let { mapObject(param, it) }
+                        array[param.index] = value?.let { mapObject(param, it) }
                     }
                 }
                 is Pair<*, *> -> parameterMap.getValue(arg.first as String).let {
-                    array[it.param.index] = arg.second?.let { value -> mapObject(it, value) }
+                    array[it.index] = arg.second?.let { value -> mapObject(it, value) }
                 }
                 else -> arg::class.memberProperties.forEach { property ->
                     if (property.visibility == KVisibility.PUBLIC && property.annotations.none { annotation -> annotation is KPropertyIgnore }) {
                         val getter = property.getAccessibleGetter()
                         parameterMap[getter.findAnnotation<KPropertyAlias>()?.value ?: property.name]?.let {
-                            array[it.param.index] = getter.call(arg)?.let { value -> mapObject(it, value) }
+                            array[it.index] = getter.call(arg)?.let { value -> mapObject(it, value) }
                         }
                     }
                 }

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -102,12 +102,6 @@ class KMapper<T : Any> private constructor(
     }
 }
 
-private fun Collection<KProperty1<*, *>>.filterTargets(): Collection<KProperty1<*, *>> {
-    return filter {
-        it.visibility == KVisibility.PUBLIC && it.annotations.none { annotation -> annotation is KPropertyIgnore }
-    }
-}
-
 @Suppress("UNCHECKED_CAST")
 internal fun <T : Any> getTarget(clazz: KClass<T>): KFunctionForCall<T> {
     val factoryConstructor: List<KFunctionForCall<T>> =

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -115,12 +115,6 @@ private fun Collection<KProperty1<*, *>>.filterTargets(): Collection<KProperty1<
     }
 }
 
-private fun KProperty1<*, *>.getAccessibleGetter(): KProperty1.Getter<*, *> {
-    // アクセス制限の有るクラスではpublicなプロパティでもゲッターにアクセスできない場合が有るため、アクセス可能にして使う
-    getter.isAccessible = true
-    return getter
-}
-
 @Suppress("UNCHECKED_CAST")
 internal fun <T : Any> getTarget(clazz: KClass<T>): KFunctionForCall<T> {
     val factoryConstructor: List<KFunctionForCall<T>> =

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -22,8 +22,8 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
 
     private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters
         .associate {
-            val param = ParameterForMap.newInstance(it, propertyNameConverter)
-            param.name to param
+            (it.findAnnotation<KPropertyAlias>()?.value ?: propertyNameConverter(it.name!!)) to
+                    ParameterForMap.newInstance(it)
         }
 
     init {

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -20,10 +20,6 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
         getTarget(clazz), propertyNameConverter
     )
 
-    private val parameters: Set<ParameterForMap<*>> = function.parameters
-        .map { ParameterForMap.newInstance(it, propertyNameConverter) }
-        .toSet()
-
     private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters
         .associate {
             val param = ParameterForMap.newInstance(it, propertyNameConverter)
@@ -31,7 +27,7 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
         }
 
     init {
-        if (parameters.isEmpty()) throw IllegalArgumentException("This function is not require arguments.")
+        if (parameterMap.isEmpty()) throw IllegalArgumentException("This function is not require arguments.")
 
         // private関数に対してもマッピングできなければ何かと不都合があるため、accessibleは書き換える
         function.isAccessible = true

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -8,6 +8,7 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.companionObjectInstance
+import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.isSuperclassOf
 import kotlin.reflect.full.memberProperties
@@ -50,10 +51,7 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
             src::class.memberProperties.filterTargets().associate { property ->
                 val getter = property.getAccessibleGetter()
 
-                val key = getter.annotations
-                    .find { it is KPropertyAlias }
-                    ?.let { (it as KPropertyAlias).value }
-                    ?: property.name
+                val key = getter.findAnnotation<KPropertyAlias>()?.value ?: property.name
 
                 key to getter
             }
@@ -78,10 +76,7 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
                         arg::class.memberProperties.filterTargets().associate { property ->
                             val getter = property.getAccessibleGetter()
 
-                            val key = getter.annotations
-                                .find { it is KPropertyAlias }
-                                ?.let { (it as KPropertyAlias).value }
-                                ?: property.name
+                            val key = getter.findAnnotation<KPropertyAlias>()?.value ?: property.name
 
                             key to { getter.call(arg) }
                         }

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -46,11 +46,9 @@ class KMapper<T : Any>(private val function: KFunction<T>, propertyNameConverter
         }.let { function.callBy(it.toMap()) }
     }
 
-    fun map(srcPair: Pair<String, Any?>): T = parameters
-        .single { it.name == srcPair.first }
-        .let {
-            function.callBy(mapOf(it.param to srcPair.second?.let { value -> mapObject(it, value) }))
-        }
+    fun map(srcPair: Pair<String, Any?>): T = parameterMap.getValue(srcPair.first).let {
+        function.callBy(mapOf(it.param to srcPair.second?.let { value -> mapObject(it, value) }))
+    }
 
     fun map(src: Any): T {
         val srcMap: Map<String, KProperty1.Getter<*, *>> =

--- a/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
@@ -6,6 +6,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.companionObjectInstance
+import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.staticFunctions
@@ -16,10 +17,7 @@ internal class ParameterForMap<T : Any> private constructor(
     val clazz: KClass<T>,
     propertyNameConverter: (String) -> String
 ) {
-    val name: String = param.annotations
-        .find { it is KPropertyAlias }
-        ?.let { (it as KPropertyAlias).value }
-        ?: propertyNameConverter(param.name!!)
+    val name: String = param.findAnnotation<KPropertyAlias>()?.value ?: propertyNameConverter(param.name!!)
 
     val javaClazz: Class<T> by lazy {
         clazz.java

--- a/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
@@ -1,12 +1,10 @@
 package com.wrongwrong.mapk.core
 
 import com.wrongwrong.mapk.annotations.KConverter
-import com.wrongwrong.mapk.annotations.KPropertyAlias
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.companionObjectInstance
-import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.staticFunctions
@@ -14,11 +12,8 @@ import kotlin.reflect.jvm.isAccessible
 
 internal class ParameterForMap<T : Any> private constructor(
     val param: KParameter,
-    val clazz: KClass<T>,
-    propertyNameConverter: (String) -> String
+    val clazz: KClass<T>
 ) {
-    val name: String = param.findAnnotation<KPropertyAlias>()?.value ?: propertyNameConverter(param.name!!)
-
     val javaClazz: Class<T> by lazy {
         clazz.java
     }
@@ -32,8 +27,8 @@ internal class ParameterForMap<T : Any> private constructor(
         creators.find { (key, _) -> input.isSubclassOf(key) }?.second
 
     companion object {
-        fun newInstance(param: KParameter, propertyNameConverter: (String) -> String): ParameterForMap<*> {
-            return ParameterForMap(param, param.type.classifier as KClass<*>, propertyNameConverter)
+        fun newInstance(param: KParameter): ParameterForMap<*> {
+            return ParameterForMap(param, param.type.classifier as KClass<*>)
         }
     }
 }

--- a/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
@@ -10,10 +10,7 @@ import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.staticFunctions
 import kotlin.reflect.jvm.isAccessible
 
-internal class ParameterForMap<T : Any> private constructor(
-    val param: KParameter,
-    val clazz: KClass<T>
-) {
+internal class ParameterForMap<T : Any> private constructor(val param: KParameter, val clazz: KClass<T>) {
     val javaClazz: Class<T> by lazy {
         clazz.java
     }

--- a/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/ParameterForMap.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.staticFunctions
 import kotlin.reflect.jvm.isAccessible
 
-internal class ParameterForMap<T : Any> private constructor(val param: KParameter, val clazz: KClass<T>) {
+internal class ParameterForMap<T : Any> private constructor(val index: Int, val clazz: KClass<T>) {
     val javaClazz: Class<T> by lazy {
         clazz.java
     }
@@ -25,7 +25,7 @@ internal class ParameterForMap<T : Any> private constructor(val param: KParamete
 
     companion object {
         fun newInstance(param: KParameter): ParameterForMap<*> {
-            return ParameterForMap(param, param.type.classifier as KClass<*>)
+            return ParameterForMap(param.index, param.type.classifier as KClass<*>)
         }
     }
 }

--- a/src/test/kotlin/mapk/core/GetTargetTest.kt
+++ b/src/test/kotlin/mapk/core/GetTargetTest.kt
@@ -3,8 +3,12 @@
 package mapk.core
 
 import com.wrongwrong.mapk.annotations.KConstructor
+import com.wrongwrong.mapk.core.KFunctionForCall
 import com.wrongwrong.mapk.core.getTarget
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.isAccessible
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
@@ -27,26 +31,34 @@ class MultipleConstructorDst @KConstructor constructor(val argument: Int) {
     @KConstructor constructor(argument: String) : this(argument.toInt())
 }
 
+@Suppress("UNCHECKED_CAST")
 @DisplayName("クラスからのコンストラクタ抽出関連テスト")
 class GetTargetTest {
+    private fun <T : Any> KFunctionForCall<T>.getTargetFunction(): KFunction<T> {
+        return this::class.memberProperties.first { it.name == "function" }.getter.let {
+            it.isAccessible = true
+            it.call(this) as KFunction<T>
+        }
+    }
+
     @Test
     @DisplayName("セカンダリコンストラクタからの取得テスト")
     fun testGetFromSecondaryConstructor() {
-        val function = getTarget(SecondaryConstructorDst::class)
+        val function = getTarget(SecondaryConstructorDst::class).getTargetFunction()
         assertTrue(function.annotations.any { it is KConstructor })
     }
 
     @Test
     @DisplayName("ファクトリーメソッドからの取得テスト")
     fun testGetFromFactoryMethod() {
-        val function = getTarget(CompanionFactoryDst::class)
+        val function = getTarget(SecondaryConstructorDst::class).getTargetFunction()
         assertTrue(function.annotations.any { it is KConstructor })
     }
 
     @Test
     @DisplayName("無指定でプライマリコンストラクタからの取得テスト")
     fun testGetFromPrimaryConstructor() {
-        val function = getTarget(ConstructorDst::class)
+        val function = getTarget(ConstructorDst::class).getTargetFunction()
         assertEquals(ConstructorDst::class.primaryConstructor, function)
     }
 

--- a/src/test/kotlin/mapk/core/ParamAliasTest.kt
+++ b/src/test/kotlin/mapk/core/ParamAliasTest.kt
@@ -1,0 +1,45 @@
+package mapk.core
+
+import com.wrongwrong.mapk.annotations.KPropertyAlias
+import com.wrongwrong.mapk.core.KMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+private data class AliasedDst(
+    val arg1: Double,
+    @param:KPropertyAlias("arg3") val arg2: Int
+)
+
+private data class AliasedSrc(
+    @get:KPropertyAlias("arg1") val arg2: Double,
+    val arg3: Int
+)
+
+@DisplayName("エイリアスを貼った場合のテスト")
+class ParamAliasTest {
+    @Test
+    @DisplayName("パラメータにエイリアスを貼った場合")
+    fun paramAliasTest() {
+        val src = mapOf(
+            "arg1" to 1.0,
+            "arg2" to "2",
+            "arg3" to 3
+        )
+
+        val result = KMapper(::AliasedDst).map(src)
+
+        assertEquals(1.0, result.arg1)
+        assertEquals(3, result.arg2)
+    }
+
+    @Test
+    @DisplayName("ゲッターにエイリアスを貼った場合")
+    fun getAliasTest() {
+        val src = AliasedSrc(1.0, 2)
+        val result = KMapper(::AliasedDst).map(src)
+
+        assertEquals(1.0, result.arg1)
+        assertEquals(2, result.arg2)
+    }
+}

--- a/src/test/kotlin/mapk/core/ParamAliasTest.kt
+++ b/src/test/kotlin/mapk/core/ParamAliasTest.kt
@@ -1,5 +1,6 @@
 package mapk.core
 
+import com.wrongwrong.mapk.annotations.KGetterAlias
 import com.wrongwrong.mapk.annotations.KPropertyAlias
 import com.wrongwrong.mapk.core.KMapper
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -12,7 +13,8 @@ private data class AliasedDst(
 )
 
 private data class AliasedSrc(
-    @get:KPropertyAlias("arg1") val arg2: Double,
+    @KGetterAlias("arg1")
+    val arg2: Double,
     val arg3: Int
 )
 

--- a/src/test/kotlin/mapk/core/SimpleKMapperTest.kt
+++ b/src/test/kotlin/mapk/core/SimpleKMapperTest.kt
@@ -6,7 +6,6 @@ import com.wrongwrong.mapk.annotations.KConstructor
 import com.wrongwrong.mapk.core.KMapper
 import java.math.BigInteger
 import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.full.primaryConstructor
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -71,7 +70,7 @@ class SimpleKMapperTest {
 
     private val mappers: Set<KMapper<out SimpleDst>> = setOf(
         KMapper(SimpleDst::class),
-        KMapper(SimpleDst::class.primaryConstructor!!),
+        KMapper(::SimpleDst),
         KMapper((SimpleDst)::factory),
         KMapper(this::instanceFunction),
         KMapper(SimpleDstExt::class)


### PR DESCRIPTION
# 処理時間の改善
以下の通り改善を行い、`map`の処理時間を75%以下に削減した。

- `KFunction.call`関数を使うように修正
  - 設計変更により処理を共通化できるようになったため、共通化
- プロパティ読み込み時に`javaGetter`を用いるように修正

# 破壊的変更
- `getter`を呼ばなくなったため、アノテーション取得のため`getter`へのエイリアスの貼り方を修正

# その他
- `readme`の修正
- テストの追加