### PR TITLE
Fix severity

### DIFF
--- a/src/main/kotlin/com/wrongwrong/mapk/core/ArgumentBucket.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/ArgumentBucket.kt
@@ -1,0 +1,26 @@
+package com.wrongwrong.mapk.core
+
+class ArgumentBucket(
+    val bucket: Array<Any?>,
+    private var initializeStatus: Int,
+    private val initializeMask: List<Int>,
+    // clone時の再計算を避けるため1回で済むようにデフォルト値化
+    private val completionValue: Int = initializeMask.reduce { l, r -> l or r }
+) : Cloneable {
+    val isInitialized: Boolean get() = initializeStatus == completionValue
+    val notInitializedParameterIndexes: List<Int> get() = initializeMask.indices.filter {
+        initializeStatus and initializeMask[it] == 0
+    }
+
+    fun setArgument(argument: Any?, index: Int) {
+        // 先に入ったものを優先するため、初期化済みなら何もしない
+        if (initializeStatus and initializeMask[index] != 0) return
+
+        bucket[index] = argument
+        initializeStatus = initializeStatus or initializeMask[index]
+    }
+
+    public override fun clone(): ArgumentBucket {
+        return ArgumentBucket(bucket.copyOf(), initializeStatus, initializeMask, completionValue)
+    }
+}

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KFunctionForCall.kt
@@ -6,16 +6,16 @@ import kotlin.reflect.jvm.isAccessible
 
 class KFunctionForCall<T>(private val function: KFunction<T>, instance: Any? = null) {
     val parameters: List<KParameter> = function.parameters
-    private val originalArray: Array<Any?>
-    val argumentArray: Array<Any?> get() = originalArray.copyOf()
+    private val originalArgumentBucket: List<Any?>
+    val argumentBucket: Array<Any?> get() = originalArgumentBucket.toTypedArray()
 
     init {
         // この関数には確実にアクセスするためアクセシビリティ書き換え
         function.isAccessible = true
-        originalArray = if (instance != null) {
-            Array(parameters.size) { if (it == 0) instance else null }
+        originalArgumentBucket = if (instance != null) {
+            List(parameters.size) { if (it == 0) instance else null }
         } else {
-            Array(parameters.size) { null }
+            List(parameters.size) { null }
         }
     }
 

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -40,64 +40,90 @@ class KMapper<T : Any> private constructor(
         if (parameterMap.isEmpty()) throw IllegalArgumentException("This function is not require arguments.")
     }
 
-    private fun bindParameters(targetBucket: Array<Any?>, src: Any) {
+    private fun throwExceptionOnNotInitialized(argumentBucket: ArgumentBucket): Nothing {
+        val notInitializedIndexes = argumentBucket.notInitializedParameterIndexes
+        function.parameters
+            .filter { it.index in notInitializedIndexes }
+            .map { it.name }
+            .joinToString(", ")
+            .let {
+                throw IllegalArgumentException("Not passed arguments: $it")
+            }
+    }
+
+    private fun bindArguments(argumentBucket: ArgumentBucket, src: Any) {
         src::class.memberProperties.forEach { property ->
             val javaGetter: Method? = property.javaGetter
             if (javaGetter != null && property.visibility == KVisibility.PUBLIC && property.annotations.none { annotation -> annotation is KPropertyIgnore }) {
                 parameterMap[property.findAnnotation<KGetterAlias>()?.value ?: property.name]?.let {
                     // javaGetterを呼び出す方が高速
                     javaGetter.isAccessible = true
-                    targetBucket[it.index] = javaGetter.invoke(src)?.let { value -> mapObject(it, value) }
+                    argumentBucket.setArgument(javaGetter.invoke(src)?.let { value -> mapObject(it, value) }, it.index)
+                    // 終了判定
+                    if (argumentBucket.isInitialized) return
                 }
             }
         }
     }
 
-    private fun bindParameters(targetBucket: Array<Any?>, src: Map<*, *>) {
+    private fun bindArguments(argumentBucket: ArgumentBucket, src: Map<*, *>) {
         src.forEach { (key, value) ->
             parameterMap[key]?.let { param ->
                 // 取得した内容がnullでなければ適切にmapする
-                targetBucket[param.index] = value?.let { mapObject(param, it) }
+                argumentBucket.setArgument(value?.let { mapObject(param, it) }, param.index)
+                // 終了判定
+                if (argumentBucket.isInitialized) return
             }
         }
     }
 
-    private fun bindParameters(targetBucket: Array<Any?>, srcPair: Pair<*, *>) {
-        parameterMap.getValue(srcPair.first.toString()).let {
-            targetBucket[it.index] = srcPair.second?.let { value -> mapObject(it, value) }
+    private fun bindArguments(argumentBucket: ArgumentBucket, srcPair: Pair<*, *>) {
+        parameterMap[srcPair.first.toString()]?.let {
+            argumentBucket.setArgument(srcPair.second?.let { value -> mapObject(it, value) }, it.index)
         }
     }
 
     fun map(srcMap: Map<String, Any?>): T {
-        val bucket: Array<Any?> = function.argumentBucket
-        bindParameters(bucket, srcMap)
+        val bucket: ArgumentBucket = function.getArgumentBucket()
+        bindArguments(bucket, srcMap)
+
+        if (!bucket.isInitialized) throwExceptionOnNotInitialized(bucket)
+
         return function.call(bucket)
     }
 
     fun map(srcPair: Pair<String, Any?>): T {
-        val bucket: Array<Any?> = function.argumentBucket
-        bindParameters(bucket, srcPair)
+        val bucket: ArgumentBucket = function.getArgumentBucket()
+        bindArguments(bucket, srcPair)
+
+        if (!bucket.isInitialized) throwExceptionOnNotInitialized(bucket)
+
         return function.call(bucket)
     }
 
     fun map(src: Any): T {
-        val bucket: Array<Any?> = function.argumentBucket
-        bindParameters(bucket, src)
+        val bucket: ArgumentBucket = function.getArgumentBucket()
+        bindArguments(bucket, src)
+
+        if (!bucket.isInitialized) throwExceptionOnNotInitialized(bucket)
+
         return function.call(bucket)
     }
 
     fun map(vararg args: Any): T {
-        val array: Array<Any?> = function.argumentBucket
+        val bucket: ArgumentBucket = function.getArgumentBucket()
 
         listOf(*args).forEach { arg ->
             when (arg) {
-                is Map<*, *> -> bindParameters(array, arg)
-                is Pair<*, *> -> bindParameters(array, arg)
-                else -> bindParameters(array, arg)
+                is Map<*, *> -> bindArguments(bucket, arg)
+                is Pair<*, *> -> bindArguments(bucket, arg)
+                else -> bindArguments(bucket, arg)
             }
         }
 
-        return function.call(array)
+        if (!bucket.isInitialized) throwExceptionOnNotInitialized(bucket)
+
+        return function.call(bucket)
     }
 }
 

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -69,25 +69,25 @@ class KMapper<T : Any> private constructor(
     }
 
     fun map(srcMap: Map<String, Any?>): T {
-        val array: Array<Any?> = function.argumentArray
+        val array: Array<Any?> = function.argumentBucket
         bindParameters(array, srcMap)
         return function.call(array)
     }
 
     fun map(srcPair: Pair<String, Any?>): T {
-        val array: Array<Any?> = function.argumentArray
+        val array: Array<Any?> = function.argumentBucket
         bindParameters(array, srcPair)
         return function.call(array)
     }
 
     fun map(src: Any): T {
-        val array: Array<Any?> = function.argumentArray
+        val array: Array<Any?> = function.argumentBucket
         bindParameters(array, src)
         return function.call(array)
     }
 
     fun map(vararg args: Any): T {
-        val array: Array<Any?> = function.argumentArray
+        val array: Array<Any?> = function.argumentBucket
 
         listOf(*args).forEach { arg ->
             when (arg) {

--- a/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
+++ b/src/main/kotlin/com/wrongwrong/mapk/core/KMapper.kt
@@ -40,50 +40,50 @@ class KMapper<T : Any> private constructor(
         if (parameterMap.isEmpty()) throw IllegalArgumentException("This function is not require arguments.")
     }
 
-    private fun bindParameters(targetArray: Array<Any?>, src: Any) {
+    private fun bindParameters(targetBucket: Array<Any?>, src: Any) {
         src::class.memberProperties.forEach { property ->
             val javaGetter: Method? = property.javaGetter
             if (javaGetter != null && property.visibility == KVisibility.PUBLIC && property.annotations.none { annotation -> annotation is KPropertyIgnore }) {
                 parameterMap[property.findAnnotation<KGetterAlias>()?.value ?: property.name]?.let {
                     // javaGetterを呼び出す方が高速
                     javaGetter.isAccessible = true
-                    targetArray[it.index] = javaGetter.invoke(src)?.let { value -> mapObject(it, value) }
+                    targetBucket[it.index] = javaGetter.invoke(src)?.let { value -> mapObject(it, value) }
                 }
             }
         }
     }
 
-    private fun bindParameters(targetArray: Array<Any?>, src: Map<*, *>) {
+    private fun bindParameters(targetBucket: Array<Any?>, src: Map<*, *>) {
         src.forEach { (key, value) ->
             parameterMap[key]?.let { param ->
                 // 取得した内容がnullでなければ適切にmapする
-                targetArray[param.index] = value?.let { mapObject(param, it) }
+                targetBucket[param.index] = value?.let { mapObject(param, it) }
             }
         }
     }
 
-    private fun bindParameters(targetArray: Array<Any?>, srcPair: Pair<*, *>) {
+    private fun bindParameters(targetBucket: Array<Any?>, srcPair: Pair<*, *>) {
         parameterMap.getValue(srcPair.first.toString()).let {
-            targetArray[it.index] = srcPair.second?.let { value -> mapObject(it, value) }
+            targetBucket[it.index] = srcPair.second?.let { value -> mapObject(it, value) }
         }
     }
 
     fun map(srcMap: Map<String, Any?>): T {
-        val array: Array<Any?> = function.argumentBucket
-        bindParameters(array, srcMap)
-        return function.call(array)
+        val bucket: Array<Any?> = function.argumentBucket
+        bindParameters(bucket, srcMap)
+        return function.call(bucket)
     }
 
     fun map(srcPair: Pair<String, Any?>): T {
-        val array: Array<Any?> = function.argumentBucket
-        bindParameters(array, srcPair)
-        return function.call(array)
+        val bucket: Array<Any?> = function.argumentBucket
+        bindParameters(bucket, srcPair)
+        return function.call(bucket)
     }
 
     fun map(src: Any): T {
-        val array: Array<Any?> = function.argumentBucket
-        bindParameters(array, src)
-        return function.call(array)
+        val bucket: Array<Any?> = function.argumentBucket
+        bindParameters(bucket, src)
+        return function.call(bucket)
     }
 
     fun map(vararg args: Any): T {


### PR DESCRIPTION
# 修正
- 0.8で無効となっていた「先に設定された方を正とする」が再度有効になるよう修正
- 0.8で無効となっていた「引数に対応する値が全て設定されていなければエラー」が再度有効になるよう修正
- 動作速度の若干の改善