### PR TITLE
Added a annotation support to use default arguments.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.15"
+version = "0.16"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(kotlin("reflect"))
-    implementation("com.github.ProjectMapK:Shared:0.6")
+    api("com.github.ProjectMapK:Shared:0.7")
 
     // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.6.0") {

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -6,6 +6,7 @@ import com.mapk.core.ArgumentBucket
 import com.mapk.core.EnumMapper
 import com.mapk.core.KFunctionForCall
 import com.mapk.core.getAliasOrName
+import com.mapk.core.isUseDefaultArgument
 import com.mapk.core.toKConstructor
 import java.lang.reflect.Method
 import kotlin.reflect.KClass
@@ -29,7 +30,7 @@ class KMapper<T : Any> private constructor(
     )
 
     private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters
-        .filter { it.kind != KParameter.Kind.INSTANCE }
+        .filter { it.kind != KParameter.Kind.INSTANCE && !it.isUseDefaultArgument() }
         .associate { (propertyNameConverter(it.getAliasOrName()!!)) to ParameterForMap.newInstance(it) }
 
     private fun bindArguments(argumentBucket: ArgumentBucket, src: Any) {

--- a/src/test/kotlin/com/mapk/kmapper/DefaultArgumentTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/DefaultArgumentTest.kt
@@ -1,0 +1,20 @@
+package com.mapk.kmapper
+
+import com.mapk.annotations.KUseDefaultArgument
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("デフォルト引数を指定するテスト")
+class DefaultArgumentTest {
+    data class Dst(val fooArgument: Int, @param:KUseDefaultArgument val barArgument: String = "default")
+    data class Src(val fooArgument: Int, val barArgument: String)
+
+    @Test
+    fun test() {
+        val src = Src(1, "src")
+
+        val result = KMapper(::Dst).map(src)
+        assertEquals(Dst(1, "default"), result)
+    }
+}


### PR DESCRIPTION
# 機能追加
- デフォルト引数を用いる（= マッピング対象にしない）機能を追加

# 不具合修正
- `shared`を`api`で指定するように修正
  - `implementation`で指定していたため、ライブラリ利用時に`shared`が利用できなくなっていた