### PR TITLE
Refactor.

### DIFF
--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -19,7 +19,7 @@ import kotlin.reflect.jvm.javaGetter
 
 class KMapper<T : Any> private constructor(
     private val function: KFunctionForCall<T>,
-    propertyNameConverter: (String) -> String = { it }
+    parameterNameConverter: (String) -> String = { it }
 ) {
     constructor(function: KFunction<T>, propertyNameConverter: (String) -> String = { it }) : this(
         KFunctionForCall(function), propertyNameConverter
@@ -31,7 +31,7 @@ class KMapper<T : Any> private constructor(
 
     private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters
         .filter { it.kind != KParameter.Kind.INSTANCE && !it.isUseDefaultArgument() }
-        .associate { (propertyNameConverter(it.getAliasOrName()!!)) to ParameterForMap.newInstance(it) }
+        .associate { (parameterNameConverter(it.getAliasOrName()!!)) to ParameterForMap.newInstance(it) }
 
     private fun bindArguments(argumentBucket: ArgumentBucket, src: Any) {
         src::class.memberProperties.forEach outer@{ property ->

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -19,7 +19,7 @@ import kotlin.reflect.jvm.javaGetter
 
 class KMapper<T : Any> private constructor(
     private val function: KFunctionForCall<T>,
-    parameterNameConverter: (String) -> String = { it }
+    parameterNameConverter: (String) -> String
 ) {
     constructor(function: KFunction<T>, propertyNameConverter: (String) -> String = { it }) : this(
         KFunctionForCall(function), propertyNameConverter

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -21,12 +21,12 @@ class KMapper<T : Any> private constructor(
     private val function: KFunctionForCall<T>,
     parameterNameConverter: (String) -> String
 ) {
-    constructor(function: KFunction<T>, propertyNameConverter: (String) -> String = { it }) : this(
-        KFunctionForCall(function), propertyNameConverter
+    constructor(function: KFunction<T>, parameterNameConverter: (String) -> String = { it }) : this(
+        KFunctionForCall(function), parameterNameConverter
     )
 
-    constructor(clazz: KClass<T>, propertyNameConverter: (String) -> String = { it }) : this(
-        clazz.toKConstructor(), propertyNameConverter
+    constructor(clazz: KClass<T>, parameterNameConverter: (String) -> String = { it }) : this(
+        clazz.toKConstructor(), parameterNameConverter
     )
 
     private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters

--- a/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
@@ -17,9 +17,7 @@ internal class ParameterForMap<T : Any> private constructor(val param: KParamete
     }
     // リストの長さが小さいと期待されるためこの形で実装しているが、理想的にはmap的なものが使いたい
     private val converters: Set<Pair<KClass<*>, KFunction<T>>> by lazy {
-        convertersFromConstructors(clazz) + convertersFromStaticMethods(
-            clazz
-        ) + convertersFromCompanionObject(clazz)
+        convertersFromConstructors(clazz) + convertersFromStaticMethods(clazz) + convertersFromCompanionObject(clazz)
     }
 
     // 引数の型がconverterに対して入力可能ならconverterを返す

--- a/src/test/kotlin/com/mapk/kmapper/ParameterNameConverterTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ParameterNameConverterTest.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test
 
 private class CamelCaseDst(val camelCase: String)
 
-@DisplayName("プロパティ名変換のテスト")
-class PropertyNameConverterTest {
+@DisplayName("パラメータ名変換のテスト")
+class ParameterNameConverterTest {
     @Test
     @DisplayName("スネークケースsrc -> キャメルケースdst")
     fun test() {


### PR DESCRIPTION
細かな修正を行った。

# 内容
- `propertyNameConverter` -> `parameterNameConverter`に引数名を修正
  - 変換対象はプロパティではなくパラメータなため
  - テスト名等も修正を行った
- `KMapper`の大本のコンストラクタではデフォルト引数が不要なため修正
- パラメータにおけるコンバータ取得処理のインデントが変だったため修正