### PR TITLE
Rename and fix architecture.

### DIFF
--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -29,9 +29,9 @@ class KMapper<T : Any> private constructor(
         clazz.toKConstructor(), parameterNameConverter
     )
 
-    private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters
+    private val parameterMap: Map<String, PlainParameterForMap<*>> = function.parameters
         .filter { it.kind != KParameter.Kind.INSTANCE && !it.isUseDefaultArgument() }
-        .associate { (parameterNameConverter(it.getAliasOrName()!!)) to ParameterForMap.newInstance(it) }
+        .associate { (parameterNameConverter(it.getAliasOrName()!!)) to PlainParameterForMap.newInstance(it) }
 
     private fun bindArguments(argumentBucket: ArgumentBucket, src: Any) {
         src::class.memberProperties.forEach outer@{ property ->
@@ -111,7 +111,7 @@ class KMapper<T : Any> private constructor(
     }
 }
 
-private fun <T : Any, R : Any> mapObject(param: ParameterForMap<R>, value: T): Any? {
+private fun <T : Any, R : Any> mapObject(param: PlainParameterForMap<R>, value: T): Any? {
     val valueClazz: KClass<*> = value::class
 
     // パラメータに対してvalueが代入可能（同じもしくは親クラス）であればそのまま用いる

--- a/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
@@ -3,7 +3,6 @@ package com.mapk.kmapper
 import com.mapk.annotations.KGetterAlias
 import com.mapk.annotations.KGetterIgnore
 import com.mapk.core.ArgumentBucket
-import com.mapk.core.EnumMapper
 import com.mapk.core.KFunctionForCall
 import com.mapk.core.getAliasOrName
 import com.mapk.core.isUseDefaultArgument
@@ -13,7 +12,6 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.KVisibility
-import kotlin.reflect.full.isSuperclassOf
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaGetter
 
@@ -108,24 +106,5 @@ class PlainKMapper<T : Any> private constructor(
         }
 
         return function.call(bucket)
-    }
-}
-
-private fun <T : Any, R : Any> mapObject(param: PlainParameterForMap<R>, value: T): Any? {
-    val valueClazz: KClass<*> = value::class
-
-    // パラメータに対してvalueが代入可能（同じもしくは親クラス）であればそのまま用いる
-    if (param.clazz.isSuperclassOf(valueClazz)) return value
-
-    val converter: KFunction<*>? = param.getConverter(valueClazz)
-
-    return when {
-        // converterに一致する組み合わせが有れば設定されていればそれを使う
-        converter != null -> converter.call(value)
-        // 要求された値がenumかつ元が文字列ならenum mapperでマップ
-        param.javaClazz.isEnum && value is String -> EnumMapper.getEnum(param.clazz.java, value)
-        // 要求されているパラメータがStringならtoStringする
-        param.clazz == String::class -> value.toString()
-        else -> throw IllegalArgumentException("Can not convert $valueClazz to ${param.clazz}")
     }
 }

--- a/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
@@ -49,7 +49,7 @@ class PlainKMapper<T : Any> private constructor(
             parameterMap[alias ?: property.name]?.let {
                 // javaGetterを呼び出す方が高速
                 javaGetter.isAccessible = true
-                argumentBucket.putIfAbsent(it.param, javaGetter.invoke(src)?.let { value -> mapObject(it, value) })
+                argumentBucket.putIfAbsent(it.param, javaGetter.invoke(src)?.let { value -> it.mapObject(value) })
                 // 終了判定
                 if (argumentBucket.isInitialized) return
             }
@@ -60,7 +60,7 @@ class PlainKMapper<T : Any> private constructor(
         src.forEach { (key, value) ->
             parameterMap[key]?.let { param ->
                 // 取得した内容がnullでなければ適切にmapする
-                argumentBucket.putIfAbsent(param.param, value?.let { mapObject(param, it) })
+                argumentBucket.putIfAbsent(param.param, value?.let { param.mapObject(value) })
                 // 終了判定
                 if (argumentBucket.isInitialized) return
             }
@@ -69,7 +69,7 @@ class PlainKMapper<T : Any> private constructor(
 
     private fun bindArguments(argumentBucket: ArgumentBucket, srcPair: Pair<*, *>) {
         parameterMap[srcPair.first.toString()]?.let {
-            argumentBucket.putIfAbsent(it.param, srcPair.second?.let { value -> mapObject(it, value) })
+            argumentBucket.putIfAbsent(it.param, srcPair.second?.let { value -> it.mapObject(value) })
         }
     }
 

--- a/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.full.isSuperclassOf
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaGetter
 
-class KMapper<T : Any> private constructor(
+class PlainKMapper<T : Any> private constructor(
     private val function: KFunctionForCall<T>,
     parameterNameConverter: (String) -> String
 ) {

--- a/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
@@ -7,8 +7,8 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.isSuperclassOf
 
-internal class PlainParameterForMap<T : Any> private constructor(val param: KParameter, val clazz: KClass<T>) {
-    val javaClazz: Class<T> by lazy {
+internal class PlainParameterForMap<T : Any> private constructor(val param: KParameter, private val clazz: KClass<T>) {
+    private val javaClazz: Class<T> by lazy {
         clazz.java
     }
     // リストの長さが小さいと期待されるためこの形で実装しているが、理想的にはmap的なものが使いたい
@@ -36,7 +36,7 @@ internal class PlainParameterForMap<T : Any> private constructor(val param: KPar
     }
 
     // 引数の型がconverterに対して入力可能ならconverterを返す
-    fun <R : Any> getConverter(input: KClass<out R>): KFunction<T>? =
+    private fun <R : Any> getConverter(input: KClass<out R>): KFunction<T>? =
         converters.find { (key, _) -> input.isSubclassOf(key) }?.second
 
     companion object {

--- a/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
@@ -1,9 +1,11 @@
 package com.mapk.kmapper
 
+import com.mapk.core.EnumMapper
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.isSuperclassOf
 
 internal class PlainParameterForMap<T : Any> private constructor(val param: KParameter, val clazz: KClass<T>) {
     val javaClazz: Class<T> by lazy {
@@ -12,6 +14,25 @@ internal class PlainParameterForMap<T : Any> private constructor(val param: KPar
     // リストの長さが小さいと期待されるためこの形で実装しているが、理想的にはmap的なものが使いたい
     private val converters: Set<Pair<KClass<*>, KFunction<T>>> by lazy {
         convertersFromConstructors(clazz) + convertersFromStaticMethods(clazz) + convertersFromCompanionObject(clazz)
+    }
+
+    fun <U : Any> mapObject(value: U): Any? {
+        val valueClazz: KClass<*> = value::class
+
+        // パラメータに対してvalueが代入可能（同じもしくは親クラス）であればそのまま用いる
+        if (clazz.isSuperclassOf(valueClazz)) return value
+
+        val converter: KFunction<*>? = getConverter(valueClazz)
+
+        return when {
+            // converterに一致する組み合わせが有れば設定されていればそれを使う
+            converter != null -> converter.call(value)
+            // 要求された値がenumかつ元が文字列ならenum mapperでマップ
+            javaClazz.isEnum && value is String -> EnumMapper.getEnum(javaClazz, value)
+            // 要求されているパラメータがStringならtoStringする
+            clazz == String::class -> value.toString()
+            else -> throw IllegalArgumentException("Can not convert $valueClazz to $clazz")
+        }
     }
 
     // 引数の型がconverterに対して入力可能ならconverterを返す

--- a/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.isSubclassOf
 
-internal class ParameterForMap<T : Any> private constructor(val param: KParameter, val clazz: KClass<T>) {
+internal class PlainParameterForMap<T : Any> private constructor(val param: KParameter, val clazz: KClass<T>) {
     val javaClazz: Class<T> by lazy {
         clazz.java
     }
@@ -19,8 +19,8 @@ internal class ParameterForMap<T : Any> private constructor(val param: KParamete
         converters.find { (key, _) -> input.isSubclassOf(key) }?.second
 
     companion object {
-        fun newInstance(param: KParameter): ParameterForMap<*> {
-            return ParameterForMap(param, param.type.classifier as KClass<*>)
+        fun newInstance(param: KParameter): PlainParameterForMap<*> {
+            return PlainParameterForMap(param, param.type.classifier as KClass<*>)
         }
     }
 }

--- a/src/test/kotlin/com/mapk/kmapper/ConverterKMapperTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ConverterKMapperTest.kt
@@ -32,7 +32,7 @@ private data class BoundStaticMethodConverterSrc(val argument: String)
 @DisplayName("コンバータ有りでのマッピングテスト")
 class ConverterKMapperTest {
     @Nested
-    @DisplayName("KMapper")
+    @DisplayName("PlainKMapper")
     inner class KMapperTest {
         @Test
         @DisplayName("コンストラクターでのコンバートテスト")

--- a/src/test/kotlin/com/mapk/kmapper/ConverterKMapperTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ConverterKMapperTest.kt
@@ -37,7 +37,7 @@ class ConverterKMapperTest {
         @Test
         @DisplayName("コンストラクターでのコンバートテスト")
         fun constructorConverterTest() {
-            val mapper = KMapper(ConstructorConverterDst::class)
+            val mapper = PlainKMapper(ConstructorConverterDst::class)
             val result = mapper.map(mapOf("argument" to 1))
 
             assertEquals(ConstructorConverter(1), result.argument)
@@ -46,7 +46,7 @@ class ConverterKMapperTest {
         @Test
         @DisplayName("コンパニオンオブジェクトに定義したコンバータでのコンバートテスト")
         fun companionConverterTest() {
-            val mapper = KMapper(CompanionConverterDst::class)
+            val mapper = PlainKMapper(CompanionConverterDst::class)
             val result = mapper.map(mapOf("argument" to "arg"))
 
             assertEquals("arg", result.argument.arg)
@@ -55,7 +55,7 @@ class ConverterKMapperTest {
         @Test
         @DisplayName("スタティックメソッドに定義したコンバータでのコンバートテスト")
         fun staticMethodConverterTest() {
-            val mapper = KMapper(StaticMethodConverterDst::class)
+            val mapper = PlainKMapper(StaticMethodConverterDst::class)
             val result = mapper.map(mapOf("argument" to "1,2,3"))
 
             assertTrue(intArrayOf(1, 2, 3) contentEquals result.argument.arg)

--- a/src/test/kotlin/com/mapk/kmapper/DefaultArgumentTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/DefaultArgumentTest.kt
@@ -18,7 +18,7 @@ class DefaultArgumentTest {
     inner class KMapperTest {
         @Test
         fun test() {
-            val result = KMapper(::Dst).map(src)
+            val result = PlainKMapper(::Dst).map(src)
             assertEquals(Dst(1, "default"), result)
         }
     }

--- a/src/test/kotlin/com/mapk/kmapper/DefaultArgumentTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/DefaultArgumentTest.kt
@@ -14,7 +14,7 @@ class DefaultArgumentTest {
     private val src = Src(1, "src")
 
     @Nested
-    @DisplayName("KMapper")
+    @DisplayName("PlainKMapper")
     inner class KMapperTest {
         @Test
         fun test() {

--- a/src/test/kotlin/com/mapk/kmapper/EnumMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/EnumMappingTest.kt
@@ -17,7 +17,7 @@ private class EnumMappingDst(val language: JvmLanguage?)
 @DisplayName("文字列 -> Enumのマッピングテスト")
 class EnumMappingTest {
     @Nested
-    @DisplayName("KMapper")
+    @DisplayName("PlainKMapper")
     inner class KMapperTest {
         private val mapper = PlainKMapper(EnumMappingDst::class)
 

--- a/src/test/kotlin/com/mapk/kmapper/EnumMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/EnumMappingTest.kt
@@ -19,7 +19,7 @@ class EnumMappingTest {
     @Nested
     @DisplayName("KMapper")
     inner class KMapperTest {
-        private val mapper = KMapper(EnumMappingDst::class)
+        private val mapper = PlainKMapper(EnumMappingDst::class)
 
         @ParameterizedTest(name = "Non-Null要求")
         @EnumSource(value = JvmLanguage::class)

--- a/src/test/kotlin/com/mapk/kmapper/KGetterIgnoreTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/KGetterIgnoreTest.kt
@@ -22,7 +22,7 @@ class KGetterIgnoreTest {
             val src1 = Src1(1, "2-1", 31)
             val src2 = Src2("2-2", 32, "4")
 
-            val mapper = KMapper(::Dst)
+            val mapper = PlainKMapper(::Dst)
 
             val dst1 = mapper.map(src1, src2)
             val dst2 = mapper.map(src2, src1)

--- a/src/test/kotlin/com/mapk/kmapper/KGetterIgnoreTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/KGetterIgnoreTest.kt
@@ -14,7 +14,7 @@ class KGetterIgnoreTest {
     data class Dst(val arg1: Int, val arg2: String, val arg3: Int, val arg4: String)
 
     @Nested
-    @DisplayName("KMapper")
+    @DisplayName("PlainKMapper")
     inner class KMapperTest {
         @Test
         @DisplayName("フィールドを無視するテスト")

--- a/src/test/kotlin/com/mapk/kmapper/ParameterNameConverterTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ParameterNameConverterTest.kt
@@ -20,7 +20,7 @@ class ParameterNameConverterTest {
             val expected = "snakeCase"
             val src = mapOf("camel_case" to expected)
 
-            val mapper = KMapper(CamelCaseDst::class) {
+            val mapper = PlainKMapper(CamelCaseDst::class) {
                 CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it)
             }
             val result = mapper.map(src)

--- a/src/test/kotlin/com/mapk/kmapper/ParameterNameConverterTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ParameterNameConverterTest.kt
@@ -12,7 +12,7 @@ private data class BoundSrc(val camel_case: String)
 @DisplayName("パラメータ名変換のテスト")
 class ParameterNameConverterTest {
     @Nested
-    @DisplayName("KMapper")
+    @DisplayName("PlainKMapper")
     inner class KMapperTest {
         @Test
         @DisplayName("スネークケースsrc -> キャメルケースdst")

--- a/src/test/kotlin/com/mapk/kmapper/PropertyAliasTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/PropertyAliasTest.kt
@@ -21,7 +21,7 @@ private data class AliasedSrc(
 @DisplayName("エイリアスを貼った場合のテスト")
 class PropertyAliasTest {
     @Nested
-    @DisplayName("KMapper")
+    @DisplayName("PlainKMapper")
     inner class KMapperTest {
         @Test
         @DisplayName("パラメータにエイリアスを貼った場合")

--- a/src/test/kotlin/com/mapk/kmapper/PropertyAliasTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/PropertyAliasTest.kt
@@ -32,7 +32,7 @@ class PropertyAliasTest {
                 "arg3" to 3
             )
 
-            val result = KMapper(::AliasedDst).map(src)
+            val result = PlainKMapper(::AliasedDst).map(src)
 
             assertEquals(1.0, result.arg1)
             assertEquals(3, result.arg2)
@@ -42,7 +42,7 @@ class PropertyAliasTest {
         @DisplayName("ゲッターにエイリアスを貼った場合")
         fun getAliasTest() {
             val src = AliasedSrc(1.0, 2)
-            val result = KMapper(::AliasedDst).map(src)
+            val result = PlainKMapper(::AliasedDst).map(src)
 
             assertEquals(1.0, result.arg1)
             assertEquals(2, result.arg2)

--- a/src/test/kotlin/com/mapk/kmapper/SimpleKMapperTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/SimpleKMapperTest.kt
@@ -76,12 +76,12 @@ class SimpleKMapperTest {
     @Nested
     @DisplayName("KMapper")
     inner class KMapperTest {
-        private val mappers: Set<KMapper<out SimpleDst>> = setOf(
-            KMapper(SimpleDst::class),
-            KMapper(::SimpleDst),
-            KMapper((SimpleDst)::factory),
-            KMapper(::instanceFunction),
-            KMapper(SimpleDstExt::class)
+        private val mappers: Set<PlainKMapper<out SimpleDst>> = setOf(
+            PlainKMapper(SimpleDst::class),
+            PlainKMapper(::SimpleDst),
+            PlainKMapper((SimpleDst)::factory),
+            PlainKMapper(::instanceFunction),
+            PlainKMapper(SimpleDstExt::class)
         )
 
         @Nested

--- a/src/test/kotlin/com/mapk/kmapper/SimpleKMapperTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/SimpleKMapperTest.kt
@@ -74,7 +74,7 @@ class SimpleKMapperTest {
     }
 
     @Nested
-    @DisplayName("KMapper")
+    @DisplayName("PlainKMapper")
     inner class KMapperTest {
         private val mappers: Set<PlainKMapper<out SimpleDst>> = setOf(
             PlainKMapper(SimpleDst::class),

--- a/src/test/kotlin/com/mapk/kmapper/StringMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/StringMappingTest.kt
@@ -11,7 +11,7 @@ private data class BoundMappingSrc(val value: Int)
 @DisplayName("文字列に対してtoStringしたものを渡すテスト")
 class StringMappingTest {
     @Nested
-    @DisplayName("KMapper")
+    @DisplayName("PlainKMapper")
     inner class KMapperTest {
         @Test
         fun test() {

--- a/src/test/kotlin/com/mapk/kmapper/StringMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/StringMappingTest.kt
@@ -15,7 +15,7 @@ class StringMappingTest {
     inner class KMapperTest {
         @Test
         fun test() {
-            val result: StringMappingDst = KMapper(StringMappingDst::class).map("value" to 1)
+            val result: StringMappingDst = PlainKMapper(StringMappingDst::class).map("value" to 1)
             assertEquals("1", result.value)
         }
     }


### PR DESCRIPTION
# 内容
## KMapperの改名
キャッシュ機能を持つ`KMapper`で置き換えるため、既存の`KMapper`を`PlainKMapper`として改名した。

## アーキテクチャ修正
値を適切に加工して返す処理はパラメータ内に有った方が都合が良いため、アーキテクチャを修正した。
また、これに伴いスコープを適切に修正した。