### PR TITLE
Add get cache and fixes.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.21"
+version = "0.22"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -65,8 +65,11 @@ class KMapper<T : Any> private constructor(
                 javaGetter.isAccessible = true
 
                 val tempCache = { value: Any, bucket: ArgumentBucket ->
-                    // javaGetterを呼び出す方が高速
-                    bucket.putIfAbsent(param.param, javaGetter.invoke(value)?.let { param.mapObject(it) })
+                    // 初期化済みであれば高コストな取得処理は行わない
+                    if (!bucket.containsKey(param.param)) {
+                        // javaGetterを呼び出す方が高速
+                        bucket.putIfAbsent(param.param, javaGetter.invoke(value)?.let { param.mapObject(it) })
+                    }
                 }
                 tempCache(src, argumentBucket)
                 tempCacheArrayList.add(tempCache)

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -40,11 +40,8 @@ class KMapper<T : Any> private constructor(
 
         // キャッシュヒットしたら登録した内容に沿って取得処理を行う
         getCache[clazz]?.let { getters ->
-            getters.forEach {
-                it(src, argumentBucket)
-                // 終了判定
-                if (argumentBucket.isInitialized) return
-            }
+            // 取得対象フィールドは十分絞り込んでいると考えられるため、終了判定は行わない
+            getters.forEach { it(src, argumentBucket) }
             return
         }
 

--- a/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
@@ -25,7 +25,7 @@ internal class ParameterForMap<T : Any> private constructor(val param: KParamete
 
         // パラメータに対してvalueが代入可能（同じもしくは親クラス）であればそのまま用いる
         if (clazz.isSuperclassOf(valueClazz)) {
-            convertCache[valueClazz] = { value }
+            convertCache[valueClazz] = { it }
             return value
         }
 

--- a/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
@@ -25,7 +25,7 @@ internal class ParameterForMap<T : Any> private constructor(val param: KParamete
 
         // パラメータに対してvalueが代入可能（同じもしくは親クラス）であればそのまま用いる
         if (clazz.isSuperclassOf(valueClazz)) {
-            convertCache[valueClazz] = { it }
+            convertCache.putIfAbsent(valueClazz) { it }
             return value
         }
 

--- a/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
@@ -1,6 +1,8 @@
 package com.mapk.kmapper
 
 import com.mapk.core.EnumMapper
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
@@ -13,7 +15,7 @@ internal class ParameterForMap<T : Any> private constructor(val param: KParamete
     // リストの長さが小さいと期待されるためこの形で実装しているが、理想的にはmap的なものが使いたい
     private val converters: Set<Pair<KClass<*>, KFunction<T>>> = clazz.getConverters()
 
-    private val convertCache: MutableMap<KClass<*>, (Any) -> Any?> = HashMap()
+    private val convertCache: ConcurrentMap<KClass<*>, (Any) -> Any?> = ConcurrentHashMap()
 
     fun <U : Any> mapObject(value: U): Any? {
         val valueClazz: KClass<*> = value::class
@@ -38,7 +40,7 @@ internal class ParameterForMap<T : Any> private constructor(val param: KParamete
             clazz == String::class -> { { it.toString() } }
             else -> throw IllegalArgumentException("Can not convert $valueClazz to $clazz")
         }
-        convertCache[valueClazz] = lambda
+        convertCache.putIfAbsent(valueClazz, lambda)
         return lambda(value)
     }
 


### PR DESCRIPTION
# 改善
オブジェクトからの値読み出し処理をキャッシュすることで大幅な高速化を実現した。

# 修正
## パラメータからの変換処理の不具合
パラメータをそのまま代入する処理で、誤って一番最初の値がキャッシュされてしまう不具合を修正した。

## 並列実行時への対応
キャッシュに`HashMap`を用いていたが、並列実行時にキャッシュへの登録処理が壊れる可能性が懸念されたため、`ConcurrentMap`のアトミック処理で`put`するように修正を行った。

# 補足
#24 で1か所修正漏れが有ったため修正を行った。