### PR TITLE
Added support for recursive mapping.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.23"
+version = "0.24"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/kotlin/com/mapk/kmapper/BoundKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundKMapper.kt
@@ -45,7 +45,7 @@ class BoundKMapper<S : Any, D : Any> private constructor(
             .filter { it.kind != KParameter.Kind.INSTANCE && !it.isUseDefaultArgument() }
             .mapNotNull {
                 val temp = srcPropertiesMap[parameterNameConverter(it.getAliasOrName()!!)]?.let { property ->
-                    BoundParameterForMap.newInstance(it, property)
+                    BoundParameterForMap.newInstance(it, property, parameterNameConverter)
                 }
 
                 // 必須引数に対応するプロパティがsrcに定義されていない場合エラー

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -56,7 +56,11 @@ internal sealed class BoundParameterForMap<S> {
     }
 
     companion object {
-        fun <S : Any> newInstance(param: KParameter, property: KProperty1<S, *>): BoundParameterForMap<S> {
+        fun <S : Any> newInstance(
+            param: KParameter,
+            property: KProperty1<S, *>,
+            parameterNameConverter: (String) -> String
+        ): BoundParameterForMap<S> {
             // ゲッターが無いならエラー
             val propertyGetter = property.javaGetter
                 ?: throw IllegalArgumentException("${property.name} does not have getter.")
@@ -85,8 +89,10 @@ internal sealed class BoundParameterForMap<S> {
             return when {
                 javaClazz.isEnum && propertyClazz == String::class -> ToEnum(param, propertyGetter, javaClazz)
                 paramClazz == String::class -> ToString(param, propertyGetter)
-                // TODO: パラメータ名のコンバータ対応、SrcがMapやPairだった場合にKMapperを用いる形への変更
-                else -> UseBoundKMapper(param, propertyGetter, BoundKMapper(paramClazz, propertyClazz))
+                // TODO: SrcがMapやPairだった場合にKMapperを用いる形への変更
+                else -> UseBoundKMapper(
+                    param, propertyGetter, BoundKMapper(paramClazz, propertyClazz, parameterNameConverter)
+                )
             }
         }
     }

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -38,11 +38,7 @@ internal sealed class BoundParameterForMap<S> {
         private val kMapper: KMapper<*>
     ) : BoundParameterForMap<S>() {
         // 1引数で呼び出すとMap/Pairが適切に処理されないため、2引数目にダミーを噛ませている
-        override fun map(src: S): Any? = kMapper.map(propertyGetter.invoke(src), dummy)
-
-        companion object {
-            private val dummy = "" to null
-        }
+        override fun map(src: S): Any? = kMapper.map(propertyGetter.invoke(src), PARAMETER_DUMMY)
     }
 
     private class UseBoundKMapper<S : Any, T : Any>(

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -31,7 +31,9 @@ class KMapper<T : Any> private constructor(
 
     private val parameterMap: Map<String, ParameterForMap<*>> = function.parameters
         .filter { it.kind != KParameter.Kind.INSTANCE && !it.isUseDefaultArgument() }
-        .associate { (parameterNameConverter(it.getAliasOrName()!!)) to ParameterForMap.newInstance(it) }
+        .associate {
+            (parameterNameConverter(it.getAliasOrName()!!)) to ParameterForMap.newInstance(it, parameterNameConverter)
+        }
 
     private val getCache: ConcurrentMap<KClass<*>, List<ArgumentBinder>> = ConcurrentHashMap()
 

--- a/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
@@ -62,6 +62,15 @@ private sealed class ParameterProcessor {
         override fun process(value: Any): Any? = converter.call(value)
     }
 
+    class UseKMapper(private val kMapper: KMapper<*>) : ParameterProcessor() {
+        override fun process(value: Any): Any? = kMapper.map(value, PARAMETER_DUMMY)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    class UseBoundKMapper<T : Any>(private val boundKMapper: BoundKMapper<T, *>) : ParameterProcessor() {
+        override fun process(value: Any): Any? = boundKMapper.map(value as T)
+    }
+
     class ToEnum(private val javaClazz: Class<*>) : ParameterProcessor() {
         override fun process(value: Any): Any? = EnumMapper.getEnum(javaClazz, value as String)
     }

--- a/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
@@ -8,7 +8,11 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.isSuperclassOf
 
-internal class ParameterForMap<T : Any> private constructor(val param: KParameter, private val clazz: KClass<T>) {
+internal class ParameterForMap<T : Any> private constructor(
+    val param: KParameter,
+    private val clazz: KClass<T>,
+    private val parameterNameConverter: (String) -> String
+) {
     private val javaClazz: Class<T> by lazy {
         clazz.java
     }
@@ -38,15 +42,18 @@ internal class ParameterForMap<T : Any> private constructor(val param: KParamete
             javaClazz.isEnum && value is String -> ParameterProcessor.ToEnum(javaClazz)
             // 要求されているパラメータがStringならtoStringする
             clazz == String::class -> ParameterProcessor.ToString
-            else -> throw IllegalArgumentException("Can not convert $valueClazz to $clazz")
+            // 入力がmapもしくはpairなら、KMapperを用いてマッピングを試みる
+            value is Map<*, *> || value is Pair<*, *> ->
+                ParameterProcessor.UseKMapper(KMapper(clazz, parameterNameConverter))
+            else -> ParameterProcessor.UseBoundKMapper(BoundKMapper(clazz, valueClazz, parameterNameConverter))
         }
         convertCache.putIfAbsent(valueClazz, processor)
         return processor.process(value)
     }
 
     companion object {
-        fun newInstance(param: KParameter): ParameterForMap<*> {
-            return ParameterForMap(param, param.type.classifier as KClass<*>)
+        fun newInstance(param: KParameter, parameterNameConverter: (String) -> String): ParameterForMap<*> {
+            return ParameterForMap(param, param.type.classifier as KClass<*>, parameterNameConverter)
         }
     }
 }

--- a/src/main/kotlin/com/mapk/kmapper/ParameterUtils.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterUtils.kt
@@ -52,3 +52,6 @@ private fun <T : Any> convertersFromCompanionObject(clazz: KClass<T>): Set<Pair<
 // 引数の型がconverterに対して入力可能ならconverterを返す
 internal fun <T : Any> Set<Pair<KClass<*>, KFunction<T>>>.getConverter(input: KClass<out T>): KFunction<T>? =
     this.find { (key, _) -> input.isSubclassOf(key) }?.second
+
+// 再帰的マッピング時にKMapperでマップする場合、引数の数が1つだと正常にマッピングが機能しないため、2引数にするために用いるダミー
+internal val PARAMETER_DUMMY = "" to null

--- a/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
@@ -29,7 +29,10 @@ class PlainKMapper<T : Any> private constructor(
 
     private val parameterMap: Map<String, PlainParameterForMap<*>> = function.parameters
         .filter { it.kind != KParameter.Kind.INSTANCE && !it.isUseDefaultArgument() }
-        .associate { (parameterNameConverter(it.getAliasOrName()!!)) to PlainParameterForMap.newInstance(it) }
+        .associate {
+            (parameterNameConverter(it.getAliasOrName()!!)) to
+                    PlainParameterForMap.newInstance(it, parameterNameConverter)
+        }
 
     private fun bindArguments(argumentBucket: ArgumentBucket, src: Any) {
         src::class.memberProperties.forEach outer@{ property ->

--- a/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("再帰的マッピングのテスト")
 class RecursiveMappingTest {
-    private data class InnerSrc(val hoge: Int, val fuga: Short, val piyo: String)
-    private data class InnerDst(val hoge: Int, val piyo: String)
+    private data class InnerSrc(val hogeHoge: Int, val fugaFuga: Short, val piyoPiyo: String)
+    private data class InnerDst(val hogeHoge: Int, val piyoPiyo: String)
 
-    private data class Src(val foo: InnerSrc, val bar: Boolean, val baz: Int)
-    private data class Dst(val foo: InnerDst, val baz: Int)
+    private data class Src(val fooFoo: InnerSrc, val barBar: Boolean, val bazBaz: Int)
+    private data class Dst(val fooFoo: InnerDst, val bazBaz: Int)
 
     companion object {
         private val src: Src = Src(InnerSrc(1, 2, "three"), true, 4)

--- a/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
@@ -14,11 +14,13 @@ class RecursiveMappingTest {
 
     private data class Src(val fooFoo: InnerSrc, val barBar: Boolean, val bazBaz: Int)
     private data class SnakeSrc(val foo_foo: InnerSnakeSrc, val bar_bar: Boolean, val baz_baz: Int)
+    private data class MapSrc(val fooFoo: Map<String, Any>, val barBar: Boolean, val bazBaz: Int)
     private data class Dst(val fooFoo: InnerDst, val bazBaz: Int)
 
     companion object {
         private val src: Src = Src(InnerSrc(1, 2, "three"), true, 4)
         private val snakeSrc: SnakeSrc = SnakeSrc(InnerSnakeSrc(1, 2, "three"), true, 4)
+        private val mapSrc: MapSrc = MapSrc(mapOf("hogeHoge" to 1, "piyoPiyo" to "three"), true, 4)
         private val expected: Dst = Dst(InnerDst(1, "three"), 4)
     }
 
@@ -38,6 +40,13 @@ class RecursiveMappingTest {
             val actual = BoundKMapper(::Dst, SnakeSrc::class) {
                 CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it)
             }.map(snakeSrc)
+            assertEquals(expected, actual)
+        }
+
+        @Test
+        @DisplayName("内部フィールドがMapの場合")
+        fun includesMap() {
+            val actual = BoundKMapper(::Dst, MapSrc::class).map(mapSrc)
             assertEquals(expected, actual)
         }
     }

--- a/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
@@ -1,5 +1,6 @@
 package com.mapk.kmapper
 
+import com.google.common.base.CaseFormat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -8,13 +9,16 @@ import org.junit.jupiter.api.Test
 @DisplayName("再帰的マッピングのテスト")
 class RecursiveMappingTest {
     private data class InnerSrc(val hogeHoge: Int, val fugaFuga: Short, val piyoPiyo: String)
+    private data class InnerSnakeSrc(val hoge_hoge: Int, val fuga_fuga: Short, val piyo_piyo: String)
     private data class InnerDst(val hogeHoge: Int, val piyoPiyo: String)
 
     private data class Src(val fooFoo: InnerSrc, val barBar: Boolean, val bazBaz: Int)
+    private data class SnakeSrc(val foo_foo: InnerSnakeSrc, val bar_bar: Boolean, val baz_baz: Int)
     private data class Dst(val fooFoo: InnerDst, val bazBaz: Int)
 
     companion object {
         private val src: Src = Src(InnerSrc(1, 2, "three"), true, 4)
+        private val snakeSrc: SnakeSrc = SnakeSrc(InnerSnakeSrc(1, 2, "three"), true, 4)
         private val expected: Dst = Dst(InnerDst(1, "three"), 4)
     }
 
@@ -22,8 +26,18 @@ class RecursiveMappingTest {
     @DisplayName("BoundKMapper")
     inner class BoundKMapperTest {
         @Test
+        @DisplayName("シンプルなマッピング")
         fun test() {
             val actual = BoundKMapper(::Dst, Src::class).map(src)
+            assertEquals(expected, actual)
+        }
+
+        @Test
+        @DisplayName("スネークケースsrc -> キャメルケースdst")
+        fun snakeToCamel() {
+            val actual = BoundKMapper(::Dst, SnakeSrc::class) {
+                CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it)
+            }.map(snakeSrc)
             assertEquals(expected, actual)
         }
     }

--- a/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
@@ -64,6 +64,33 @@ class RecursiveMappingTest {
     }
 
     @Nested
+    @DisplayName("PlainKMapper")
+    inner class PlainKMapperTest {
+        @Test
+        @DisplayName("シンプルなマッピング")
+        fun test() {
+            val actual = PlainKMapper(::Dst).map(src)
+            assertEquals(expected, actual)
+        }
+
+        @Test
+        @DisplayName("スネークケースsrc -> キャメルケースdst")
+        fun snakeToCamel() {
+            val actual = PlainKMapper(::Dst) {
+                CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it)
+            }.map(snakeSrc)
+            assertEquals(expected, actual)
+        }
+
+        @Test
+        @DisplayName("内部フィールドがMapの場合")
+        fun includesMap() {
+            val actual = PlainKMapper(::Dst).map(mapSrc)
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Nested
     @DisplayName("BoundKMapper")
     inner class BoundKMapperTest {
         @Test

--- a/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
@@ -1,0 +1,30 @@
+package com.mapk.kmapper
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("再帰的マッピングのテスト")
+class RecursiveMappingTest {
+    private data class InnerSrc(val hoge: Int, val fuga: Short, val piyo: String)
+    private data class InnerDst(val hoge: Int, val piyo: String)
+
+    private data class Src(val foo: InnerSrc, val bar: Boolean, val baz: Int)
+    private data class Dst(val foo: InnerDst, val baz: Int)
+
+    companion object {
+        private val src: Src = Src(InnerSrc(1, 2, "three"), true, 4)
+        private val expected: Dst = Dst(InnerDst(1, "three"), 4)
+    }
+
+    @Nested
+    @DisplayName("BoundKMapper")
+    inner class BoundKMapperTest {
+        @Test
+        fun test() {
+            val actual = BoundKMapper(::Dst, Src::class).map(src)
+            assertEquals(expected, actual)
+        }
+    }
+}

--- a/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
@@ -25,6 +25,33 @@ class RecursiveMappingTest {
     }
 
     @Nested
+    @DisplayName("KMapper")
+    inner class KMapperTest {
+        @Test
+        @DisplayName("シンプルなマッピング")
+        fun test() {
+            val actual = KMapper(::Dst).map(src)
+            assertEquals(expected, actual)
+        }
+
+        @Test
+        @DisplayName("スネークケースsrc -> キャメルケースdst")
+        fun snakeToCamel() {
+            val actual = KMapper(::Dst) {
+                CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it)
+            }.map(snakeSrc)
+            assertEquals(expected, actual)
+        }
+
+        @Test
+        @DisplayName("内部フィールドがMapの場合")
+        fun includesMap() {
+            val actual = KMapper(::Dst).map(mapSrc)
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Nested
     @DisplayName("BoundKMapper")
     inner class BoundKMapperTest {
         @Test

--- a/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/RecursiveMappingTest.kt
@@ -8,9 +8,21 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("再帰的マッピングのテスト")
 class RecursiveMappingTest {
-    private data class InnerSrc(val hogeHoge: Int, val fugaFuga: Short, val piyoPiyo: String)
-    private data class InnerSnakeSrc(val hoge_hoge: Int, val fuga_fuga: Short, val piyo_piyo: String)
-    private data class InnerDst(val hogeHoge: Int, val piyoPiyo: String)
+    private data class InnerSrc(
+        val hogeHoge: Int,
+        val fugaFuga: Short,
+        val piyoPiyo: String,
+        val mogeMoge: Pair<String, Int>
+    )
+    private data class InnerSnakeSrc(
+        val hoge_hoge: Int,
+        val fuga_fuga: Short,
+        val piyo_piyo: String,
+        val moge_moge: Pair<String, Int>
+    )
+
+    private data class InnerInnerDst(val poiPoi: Int?)
+    private data class InnerDst(val hogeHoge: Int, val piyoPiyo: String, val mogeMoge: InnerInnerDst)
 
     private data class Src(val fooFoo: InnerSrc, val barBar: Boolean, val bazBaz: Int)
     private data class SnakeSrc(val foo_foo: InnerSnakeSrc, val bar_bar: Boolean, val baz_baz: Int)
@@ -18,10 +30,10 @@ class RecursiveMappingTest {
     private data class Dst(val fooFoo: InnerDst, val bazBaz: Int)
 
     companion object {
-        private val src: Src = Src(InnerSrc(1, 2, "three"), true, 4)
-        private val snakeSrc: SnakeSrc = SnakeSrc(InnerSnakeSrc(1, 2, "three"), true, 4)
-        private val mapSrc: MapSrc = MapSrc(mapOf("hogeHoge" to 1, "piyoPiyo" to "three"), true, 4)
-        private val expected: Dst = Dst(InnerDst(1, "three"), 4)
+        private val src = Src(InnerSrc(1, 2, "three", "poiPoi" to 5), true, 4)
+        private val snakeSrc = SnakeSrc(InnerSnakeSrc(1, 2, "three", "poi_poi" to 5), true, 4)
+        private val mapSrc = MapSrc(mapOf("hogeHoge" to 1, "piyoPiyo" to "three", "mogeMoge" to ("poiPoi" to 5)), true, 4)
+        private val expected = Dst(InnerDst(1, "three", InnerInnerDst(5)), 4)
     }
 
     @Nested


### PR DESCRIPTION
# 内容
これまで`KMapper`ではコンバータが無くプロパティとパラメータの型が異なる場合マッピングできないものとして扱っていたが、内部的に`KMapper`シリーズを用いて再帰的にマッピングできるよう機能追加を行った。

## `KMapper`/`BoundKMapper`
`KMapper`/`BoundKMapper`では、以下の条件でマッパーを宣言して再帰的マッピングを行うよう修正を行った。

- `Map`/`Pair`が入力 -> `KMapper`
- `Map`/`Pair`以外のオブジェクトが入力 -> `BoundKMapper`

## `PlainKMapper`
内部で`PlainKMapper`を宣言して再帰的マッピングを行うよう修正を行った。