### PR TITLE
Improved processing efficiency.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(kotlin("reflect"))
-    api("com.github.ProjectMapK:Shared:0.13")
+    api("com.github.ProjectMapK:Shared:0.14")
 
     // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.6.2") {

--- a/src/main/kotlin/com/mapk/kmapper/BoundKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundKMapper.kt
@@ -55,7 +55,7 @@ class BoundKMapper<S : Any, D : Any> private constructor(
         val adaptor = function.getArgumentAdaptor()
 
         parameters.forEach {
-            adaptor.putIfAbsent(it.name, it.map(src))
+            adaptor.forcePut(it.name, it.map(src))
         }
 
         return function.call(adaptor)

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -128,10 +128,8 @@ class KMapper<T : Any> private constructor(
 
 private class ArgumentBinder(private val param: ParameterForMap<*>, private val javaGetter: Method) {
     fun bindArgument(src: Any, adaptor: ArgumentAdaptor) {
-        // 初期化済みであれば高コストな取得処理は行わない
-        if (!adaptor.isInitialized(param.name)) {
-            // javaGetterを呼び出す方が高速
-            adaptor.putIfAbsent(param.name, javaGetter.invoke(src)?.let { param.mapObject(it) })
+        adaptor.putIfAbsent(param.name) {
+            javaGetter.invoke(src)?.let { param.mapObject(it) }
         }
     }
 }

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -75,7 +75,7 @@ class KMapper<T : Any> private constructor(
         src.forEach { (key, value) ->
             parameterMap[key]?.let { param ->
                 // 取得した内容がnullでなければ適切にmapする
-                argumentAdaptor.putIfAbsent(param.name, value?.let { param.mapObject(value) })
+                argumentAdaptor.putIfAbsent(param.name) { value?.let { param.mapObject(value) } }
                 // 終了判定
                 if (argumentAdaptor.isFullInitialized()) return
             }
@@ -86,7 +86,7 @@ class KMapper<T : Any> private constructor(
         val key = srcPair.first.toString()
 
         parameterMap[key]?.let {
-            argumentAdaptor.putIfAbsent(key, srcPair.second?.let { value -> it.mapObject(value) })
+            argumentAdaptor.putIfAbsent(key) { srcPair.second?.let { value -> it.mapObject(value) } }
         }
     }
 

--- a/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
@@ -20,8 +20,9 @@ internal class ParameterForMap<T : Any>(
     }
     // リストの長さが小さいと期待されるためこの形で実装しているが、理想的にはmap的なものが使いたい
     @Suppress("UNCHECKED_CAST")
-    private val converters: Set<Pair<KClass<*>, KFunction<T>>> =
+    private val converters: Set<Pair<KClass<*>, KFunction<T>>> by lazy {
         (param.getConverters() as Set<Pair<KClass<*>, KFunction<T>>>) + clazz.getConverters()
+    }
 
     private val convertCache: ConcurrentMap<KClass<*>, ParameterProcessor> = ConcurrentHashMap()
 

--- a/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
@@ -47,7 +47,7 @@ class PlainKMapper<T : Any> private constructor(
             parameterMap[alias!!]?.let {
                 // javaGetterを呼び出す方が高速
                 javaGetter.isAccessible = true
-                argumentAdaptor.putIfAbsent(alias!!, javaGetter.invoke(src)?.let { value -> it.mapObject(value) })
+                argumentAdaptor.putIfAbsent(alias!!) { javaGetter.invoke(src)?.let { value -> it.mapObject(value) } }
                 // 終了判定
                 if (argumentAdaptor.isFullInitialized()) return
             }
@@ -58,7 +58,7 @@ class PlainKMapper<T : Any> private constructor(
         src.forEach { (key, value) ->
             parameterMap[key]?.let { param ->
                 // 取得した内容がnullでなければ適切にmapする
-                argumentAdaptor.putIfAbsent(key as String, value?.let { param.mapObject(value) })
+                argumentAdaptor.putIfAbsent(key as String) { value?.let { param.mapObject(value) } }
                 // 終了判定
                 if (argumentAdaptor.isFullInitialized()) return
             }
@@ -69,7 +69,7 @@ class PlainKMapper<T : Any> private constructor(
         val key = srcPair.first.toString()
 
         parameterMap[key]?.let {
-            argumentBucket.putIfAbsent(key, srcPair.second?.let { value -> it.mapObject(value) })
+            argumentBucket.putIfAbsent(key) { srcPair.second?.let { value -> it.mapObject(value) } }
         }
     }
 

--- a/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
@@ -17,8 +17,9 @@ internal class PlainParameterForMap<T : Any>(
     }
     // リストの長さが小さいと期待されるためこの形で実装しているが、理想的にはmap的なものが使いたい
     @Suppress("UNCHECKED_CAST")
-    private val converters: Set<Pair<KClass<*>, KFunction<T>>> =
+    private val converters: Set<Pair<KClass<*>, KFunction<T>>> by lazy {
         (param.getConverters() as Set<Pair<KClass<*>, KFunction<T>>>) + clazz.getConverters()
+    }
 
     fun <U : Any> mapObject(value: U): Any? {
         val valueClazz: KClass<*> = value::class


### PR DESCRIPTION
# 内容
- コンバータの取得処理は重いため、`KMapper`と`PlainKMapper`では遅延初期化するように修正
- `BoundKMapper`では初期化チェックが不要なため、省いて高速化
- `KMapper`と`PlainKMapper`で`put`時の初期化チェックを減らして高速化