### PR TITLE
Fixes BoundKMapper and add tests.

### DIFF
--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -24,7 +24,7 @@ internal sealed class BoundParameterForMap<S> {
         override fun map(src: S): Any? = propertyGetter.invoke(src)
     }
 
-    private class UseConverter<S : Any>(
+    internal class UseConverter<S : Any>(
         override val name: String,
         override val propertyGetter: Method,
         private val converter: KFunction<*>

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -41,7 +41,7 @@ internal sealed class BoundParameterForMap<S> {
         override fun map(src: S): Any? = propertyGetter.invoke(src)?.let { kMapper.map(it, PARAMETER_DUMMY) }
     }
 
-    private class UseBoundKMapper<S : Any, T : Any>(
+    internal class UseBoundKMapper<S : Any, T : Any>(
         override val name: String,
         override val propertyGetter: Method,
         private val boundKMapper: BoundKMapper<T, *>

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -49,7 +49,7 @@ internal sealed class BoundParameterForMap<S> {
         override fun map(src: S): Any? = boundKMapper.map(propertyGetter.invoke(src) as T)
     }
 
-    private class ToEnum<S : Any>(
+    internal class ToEnum<S : Any>(
         override val name: String,
         override val propertyGetter: Method,
         private val paramClazz: Class<*>

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -32,7 +32,7 @@ internal sealed class BoundParameterForMap<S> {
         override fun map(src: S): Any? = converter.call(propertyGetter.invoke(src))
     }
 
-    private class UseKMapper<S : Any>(
+    internal class UseKMapper<S : Any>(
         override val name: String,
         override val propertyGetter: Method,
         private val kMapper: KMapper<*>

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -38,7 +38,7 @@ internal sealed class BoundParameterForMap<S> {
         private val kMapper: KMapper<*>
     ) : BoundParameterForMap<S>() {
         // 1引数で呼び出すとMap/Pairが適切に処理されないため、2引数目にダミーを噛ませている
-        override fun map(src: S): Any? = kMapper.map(propertyGetter.invoke(src), PARAMETER_DUMMY)
+        override fun map(src: S): Any? = propertyGetter.invoke(src)?.let { kMapper.map(it, PARAMETER_DUMMY) }
     }
 
     private class UseBoundKMapper<S : Any, T : Any>(

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -46,7 +46,7 @@ internal sealed class BoundParameterForMap<S> {
         override val propertyGetter: Method,
         private val boundKMapper: BoundKMapper<T, *>
     ) : BoundParameterForMap<S>() {
-        override fun map(src: S): Any? = boundKMapper.map(propertyGetter.invoke(src) as T)
+        override fun map(src: S): Any? = (propertyGetter.invoke(src))?.let { boundKMapper.map(it as T) }
     }
 
     internal class ToEnum<S : Any>(

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -61,7 +61,7 @@ internal sealed class BoundParameterForMap<S> {
         override val name: String,
         override val propertyGetter: Method
     ) : BoundParameterForMap<S>() {
-        override fun map(src: S): String? = propertyGetter.invoke(src).toString()
+        override fun map(src: S): String? = propertyGetter.invoke(src)?.toString()
     }
 
     companion object {

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -57,7 +57,7 @@ internal sealed class BoundParameterForMap<S> {
         override fun map(src: S): Any? = EnumMapper.getEnum(paramClazz, propertyGetter.invoke(src) as String)
     }
 
-    private class ToString<S : Any>(
+    internal class ToString<S : Any>(
         override val name: String,
         override val propertyGetter: Method
     ) : BoundParameterForMap<S>() {

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -54,7 +54,7 @@ internal sealed class BoundParameterForMap<S> {
         override val propertyGetter: Method,
         private val paramClazz: Class<*>
     ) : BoundParameterForMap<S>() {
-        override fun map(src: S): Any? = EnumMapper.getEnum(paramClazz, propertyGetter.invoke(src) as String)
+        override fun map(src: S): Any? = EnumMapper.getEnum(paramClazz, propertyGetter.invoke(src) as String?)
     }
 
     internal class ToString<S : Any>(

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -17,7 +17,7 @@ internal sealed class BoundParameterForMap<S> {
 
     abstract fun map(src: S): Any?
 
-    private class Plain<S : Any>(
+    internal class Plain<S : Any>(
         override val name: String,
         override val propertyGetter: Method
     ) : BoundParameterForMap<S>() {

--- a/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
@@ -1,5 +1,6 @@
 package com.mapk.kmapper
 
+import com.mapk.kmapper.testcommons.JvmLanguage
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaGetter
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -11,6 +12,28 @@ import org.junit.jupiter.api.Test
 @DisplayName("BoundKMapperのパラメータテスト")
 class BoundParameterForMapTest {
     data class IntSrc(val int: Int?)
+    data class StringSrc(val str: String?)
+
+    @Nested
+    @DisplayName("ToEnumのテスト")
+    inner class ToEnumTest {
+        private val parameter = BoundParameterForMap.ToEnum<StringSrc>(
+            "", StringSrc::class.memberProperties.single().javaGetter!!, JvmLanguage::class.java
+        )
+
+        @Test
+        @DisplayName("not null")
+        fun isNotNull() {
+            val result = parameter.map(StringSrc("Java"))
+            assertEquals(JvmLanguage.Java, result)
+        }
+
+        @Test
+        @DisplayName("null")
+        fun isNull() {
+            assertNull(parameter.map(StringSrc(null)))
+        }
+    }
 
     @Nested
     @DisplayName("ToStringのテスト")

--- a/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
@@ -15,6 +15,26 @@ class BoundParameterForMapTest {
     data class StringSrc(val str: String?)
 
     @Nested
+    @DisplayName("Plainのテスト")
+    inner class PlainTest {
+        private val parameter =
+            BoundParameterForMap.Plain<StringSrc>("", StringSrc::class.memberProperties.single().javaGetter!!)
+
+        @Test
+        @DisplayName("not null")
+        fun isNotNull() {
+            val result = parameter.map(StringSrc("sss"))
+            assertEquals("sss", result)
+        }
+
+        @Test
+        @DisplayName("null")
+        fun isNull() {
+            assertNull(parameter.map(StringSrc(null)))
+        }
+    }
+
+    @Nested
     @DisplayName("ToEnumのテスト")
     inner class ToEnumTest {
         private val parameter = BoundParameterForMap.ToEnum<StringSrc>(

--- a/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
@@ -16,7 +16,7 @@ class BoundParameterForMapTest {
     @DisplayName("ToStringのテスト")
     inner class ToStringTest {
         private val parameter =
-            BoundParameterForMap.ToString<Any>("", IntSrc::class.memberProperties.single().javaGetter!!)
+            BoundParameterForMap.ToString<IntSrc>("", IntSrc::class.memberProperties.single().javaGetter!!)
 
         @Test
         @DisplayName("not null")

--- a/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
@@ -13,6 +13,9 @@ import org.junit.jupiter.api.Test
 class BoundParameterForMapTest {
     data class IntSrc(val int: Int?)
     data class StringSrc(val str: String?)
+    data class ObjectSrc(val obj: Any?)
+
+    data class ObjectDst(val int: Int?, val str: String?)
 
     @Nested
     @DisplayName("Plainのテスト")
@@ -56,6 +59,27 @@ class BoundParameterForMapTest {
         @DisplayName("null")
         fun isNull() {
             assertNull(parameter.map(IntSrc(null)))
+        }
+    }
+
+    @Nested
+    @DisplayName("UseKMapperのテスト")
+    inner class UseKMapperTest {
+        private val parameter = BoundParameterForMap.UseKMapper<ObjectSrc>(
+            "", ObjectSrc::class.memberProperties.single().javaGetter!!, KMapper(::ObjectDst)
+        )
+
+        @Test
+        @DisplayName("not null")
+        fun isNotNull() {
+            val result = parameter.map(ObjectSrc(mapOf("int" to 0, "str" to null)))
+            assertEquals(ObjectDst(0, null), result)
+        }
+
+        @Test
+        @DisplayName("null")
+        fun isNull() {
+            assertNull(parameter.map(ObjectSrc(null)))
         }
     }
 

--- a/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 class BoundParameterForMapTest {
     data class IntSrc(val int: Int?)
     data class StringSrc(val str: String?)
+    data class InnerSrc(val int: Int?, val str: String?)
     data class ObjectSrc(val obj: Any?)
 
     data class ObjectDst(val int: Int?, val str: String?)
@@ -74,6 +75,27 @@ class BoundParameterForMapTest {
         fun isNotNull() {
             val result = parameter.map(ObjectSrc(mapOf("int" to 0, "str" to null)))
             assertEquals(ObjectDst(0, null), result)
+        }
+
+        @Test
+        @DisplayName("null")
+        fun isNull() {
+            assertNull(parameter.map(ObjectSrc(null)))
+        }
+    }
+
+    @Nested
+    @DisplayName("UseBoundKMapperのテスト")
+    inner class UseBoundKMapperTest {
+        private val parameter = BoundParameterForMap.UseBoundKMapper<ObjectSrc, InnerSrc>(
+            "", ObjectSrc::class.memberProperties.single().javaGetter!!, BoundKMapper(::ObjectDst, InnerSrc::class)
+        )
+
+        @Test
+        @DisplayName("not null")
+        fun isNotNull() {
+            val result = parameter.map(ObjectSrc(InnerSrc(null, "str")))
+            assertEquals(ObjectDst(null, "str"), result)
         }
 
         @Test

--- a/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
@@ -1,0 +1,34 @@
+package com.mapk.kmapper
+
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.javaGetter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("BoundKMapperのパラメータテスト")
+class BoundParameterForMapTest {
+    data class IntSrc(val int: Int?)
+
+    @Nested
+    @DisplayName("ToStringのテスト")
+    inner class ToStringTest {
+        private val parameter =
+            BoundParameterForMap.ToString<Any>("", IntSrc::class.memberProperties.single().javaGetter!!)
+
+        @Test
+        @DisplayName("not null")
+        fun isNotNull() {
+            val result = parameter.map(IntSrc(1))
+            assertEquals("1", result)
+        }
+
+        @Test
+        @DisplayName("null")
+        fun isNull() {
+            assertNull(parameter.map(IntSrc(null)))
+        }
+    }
+}

--- a/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/BoundParameterForMapTest.kt
@@ -35,6 +35,31 @@ class BoundParameterForMapTest {
     }
 
     @Nested
+    @DisplayName("UseConverterのテスト")
+    inner class UseConverterTest {
+        // アクセシビリティの問題で公開状態に設定
+        @Suppress("MemberVisibilityCanBePrivate")
+        fun makeTwiceOrNull(int: Int?) = int?.let { it * 2 }
+
+        private val parameter = BoundParameterForMap.UseConverter<IntSrc>(
+            "", IntSrc::class.memberProperties.single().javaGetter!!, this::makeTwiceOrNull
+        )
+
+        @Test
+        @DisplayName("not null")
+        fun isNotNull() {
+            val result = parameter.map(IntSrc(1))
+            assertEquals(2, result)
+        }
+
+        @Test
+        @DisplayName("null")
+        fun isNull() {
+            assertNull(parameter.map(IntSrc(null)))
+        }
+    }
+
+    @Nested
     @DisplayName("ToEnumのテスト")
     inner class ToEnumTest {
         private val parameter = BoundParameterForMap.ToEnum<StringSrc>(

--- a/src/test/kotlin/com/mapk/kmapper/EnumMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/EnumMappingTest.kt
@@ -8,10 +8,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
-enum class JvmLanguage {
-    Java, Scala, Groovy, Kotlin
-}
-
 private class EnumMappingDst(val language: JvmLanguage?)
 
 @DisplayName("文字列 -> Enumのマッピングテスト")

--- a/src/test/kotlin/com/mapk/kmapper/EnumMappingTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/EnumMappingTest.kt
@@ -2,6 +2,7 @@
 
 package com.mapk.kmapper
 
+import com.mapk.kmapper.testcommons.JvmLanguage
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested

--- a/src/test/kotlin/com/mapk/kmapper/TestCommons.kt
+++ b/src/test/kotlin/com/mapk/kmapper/TestCommons.kt
@@ -1,0 +1,5 @@
+package com.mapk.kmapper
+
+enum class JvmLanguage {
+    Java, Scala, Groovy, Kotlin
+}

--- a/src/test/kotlin/com/mapk/kmapper/testcommons/JvmLanguage.kt
+++ b/src/test/kotlin/com/mapk/kmapper/testcommons/JvmLanguage.kt
@@ -1,4 +1,4 @@
-package com.mapk.kmapper
+package com.mapk.kmapper.testcommons
 
 enum class JvmLanguage {
     Java, Scala, Groovy, Kotlin


### PR DESCRIPTION
# バグ修正
`BoundKMapper`について以下のバグを修正した。
- 内部的にパラメータを`KMapper`でマップする際、入力が`null`だと落ちる
- 内部的にパラメータを`BoundKMapper`でマップする際、入力が`null`だと落ちる
- 内部的にパラメータを`EnumMapper`でマップする際、入力が`null`だと落ちる
- 内部的にパラメータを`toString`してマップする際、入力が`null`だと落ちる

# テスト追加
`BoundParameterForMap`全般にテストを追加した。