### PR TITLE
Fine-grained optimization.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(kotlin("reflect"))
-    api("com.github.ProjectMapK:Shared:0.15")
+    api("com.github.ProjectMapK:Shared:0.16")
 
     // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.6.2") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.29"
+version = "0.30"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/kotlin/com/mapk/kmapper/BoundKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundKMapper.kt
@@ -18,11 +18,11 @@ class BoundKMapper<S : Any, D : Any> private constructor(
     src: KClass<S>,
     parameterNameConverter: ((String) -> String)?
 ) {
-    constructor(function: KFunction<D>, src: KClass<S>, parameterNameConverter: (String) -> String = { it }) : this(
+    constructor(function: KFunction<D>, src: KClass<S>, parameterNameConverter: ((String) -> String)? = null) : this(
         KFunctionForCall(function, parameterNameConverter), src, parameterNameConverter
     )
 
-    constructor(clazz: KClass<D>, src: KClass<S>, parameterNameConverter: (String) -> String = { it }) : this(
+    constructor(clazz: KClass<D>, src: KClass<S>, parameterNameConverter: ((String) -> String)? = null) : this(
         clazz.toKConstructor(parameterNameConverter), src, parameterNameConverter
     )
 

--- a/src/main/kotlin/com/mapk/kmapper/BoundKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundKMapper.kt
@@ -16,7 +16,7 @@ import kotlin.reflect.jvm.jvmName
 class BoundKMapper<S : Any, D : Any> private constructor(
     private val function: KFunctionForCall<D>,
     src: KClass<S>,
-    parameterNameConverter: (String) -> String
+    parameterNameConverter: ((String) -> String)?
 ) {
     constructor(function: KFunction<D>, src: KClass<S>, parameterNameConverter: (String) -> String = { it }) : this(
         KFunctionForCall(function, parameterNameConverter), src, parameterNameConverter

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -68,7 +68,7 @@ internal sealed class BoundParameterForMap<S> {
         fun <S : Any> newInstance(
             param: ValueParameter<*>,
             property: KProperty1<S, *>,
-            parameterNameConverter: (String) -> String
+            parameterNameConverter: ((String) -> String)?
         ): BoundParameterForMap<S> {
             // ゲッターが無いならエラー
             val propertyGetter = property.javaGetter

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -16,7 +16,7 @@ import kotlin.reflect.jvm.javaGetter
 
 class KMapper<T : Any> private constructor(
     private val function: KFunctionForCall<T>,
-    parameterNameConverter: (String) -> String
+    parameterNameConverter: ((String) -> String)?
 ) {
     constructor(function: KFunction<T>, parameterNameConverter: (String) -> String = { it }) : this(
         KFunctionForCall(function, parameterNameConverter), parameterNameConverter

--- a/src/main/kotlin/com/mapk/kmapper/KMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/KMapper.kt
@@ -18,11 +18,11 @@ class KMapper<T : Any> private constructor(
     private val function: KFunctionForCall<T>,
     parameterNameConverter: ((String) -> String)?
 ) {
-    constructor(function: KFunction<T>, parameterNameConverter: (String) -> String = { it }) : this(
+    constructor(function: KFunction<T>, parameterNameConverter: ((String) -> String)? = null) : this(
         KFunctionForCall(function, parameterNameConverter), parameterNameConverter
     )
 
-    constructor(clazz: KClass<T>, parameterNameConverter: (String) -> String = { it }) : this(
+    constructor(clazz: KClass<T>, parameterNameConverter: ((String) -> String)? = null) : this(
         clazz.toKConstructor(parameterNameConverter), parameterNameConverter
     )
 

--- a/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
@@ -61,7 +61,7 @@ private sealed class ParameterProcessor {
     abstract fun process(value: Any): Any?
 
     object Plain : ParameterProcessor() {
-        override fun process(value: Any): Any? = value
+        override fun process(value: Any): Any = value
     }
 
     class UseConverter(private val converter: KFunction<*>) : ParameterProcessor() {
@@ -82,6 +82,6 @@ private sealed class ParameterProcessor {
     }
 
     object ToString : ParameterProcessor() {
-        override fun process(value: Any): Any? = value.toString()
+        override fun process(value: Any): Any = value.toString()
     }
 }

--- a/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/ParameterForMap.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.full.isSuperclassOf
 
 internal class ParameterForMap<T : Any>(
     param: ValueParameter<T>,
-    private val parameterNameConverter: (String) -> String
+    private val parameterNameConverter: ((String) -> String)?
 ) {
     val name: String = param.name
     private val clazz: KClass<T> = param.requiredClazz

--- a/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.jvm.javaGetter
 
 class PlainKMapper<T : Any> private constructor(
     private val function: KFunctionForCall<T>,
-    parameterNameConverter: (String) -> String
+    parameterNameConverter: ((String) -> String)?
 ) {
     constructor(function: KFunction<T>, parameterNameConverter: (String) -> String = { it }) : this(
         KFunctionForCall(function, parameterNameConverter), parameterNameConverter

--- a/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainKMapper.kt
@@ -16,11 +16,11 @@ class PlainKMapper<T : Any> private constructor(
     private val function: KFunctionForCall<T>,
     parameterNameConverter: ((String) -> String)?
 ) {
-    constructor(function: KFunction<T>, parameterNameConverter: (String) -> String = { it }) : this(
+    constructor(function: KFunction<T>, parameterNameConverter: ((String) -> String)? = null) : this(
         KFunctionForCall(function, parameterNameConverter), parameterNameConverter
     )
 
-    constructor(clazz: KClass<T>, parameterNameConverter: (String) -> String = { it }) : this(
+    constructor(clazz: KClass<T>, parameterNameConverter: ((String) -> String)? = null) : this(
         clazz.toKConstructor(parameterNameConverter), parameterNameConverter
     )
 

--- a/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/PlainParameterForMap.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.full.isSuperclassOf
 
 internal class PlainParameterForMap<T : Any>(
     param: ValueParameter<T>,
-    private val parameterNameConverter: (String) -> String
+    private val parameterNameConverter: ((String) -> String)?
 ) {
     private val clazz: KClass<T> = param.requiredClazz
 


### PR DESCRIPTION
# parameterNameConverterの取り扱いの修正
`Shared`のアップデートに追従し、`parameterNameConverter`を`nullable`に、またデフォルト引数を`null`に修正した。

# ParameterProcessorの微修正
`null`を返さないものに関しては`non-null`指定に修正した。
