### PR TITLE
Add dummy constructors.

### DIFF
--- a/src/main/kotlin/com/mapk/kmapper/DummyConstructor.kt
+++ b/src/main/kotlin/com/mapk/kmapper/DummyConstructor.kt
@@ -7,17 +7,25 @@ import com.mapk.kmapper.KMapper as Normal
 import com.mapk.kmapper.PlainKMapper as Plain
 import kotlin.reflect.KFunction
 
+inline fun <reified S : Any, reified D : Any> BoundKMapper(): Bound<S, D> = Bound(D::class, S::class)
+
 inline fun <reified S : Any, reified D : Any> BoundKMapper(
-    noinline parameterNameConverter: ((String) -> String)? = null
-) = Bound(D::class, S::class, parameterNameConverter)
+    noinline parameterNameConverter: ((String) -> String)
+): Bound<S, D> = Bound(D::class, S::class, parameterNameConverter)
+
+inline fun <reified S : Any, D : Any> BoundKMapper(function: KFunction<D>): Bound<S, D> = Bound(function, S::class)
 
 inline fun <reified S : Any, D : Any> BoundKMapper(
     function: KFunction<D>,
-    noinline parameterNameConverter: ((String) -> String)? = null
-) = Bound(function, S::class, parameterNameConverter)
+    noinline parameterNameConverter: ((String) -> String)
+): Bound<S, D> = Bound(function, S::class, parameterNameConverter)
 
-inline fun <reified T : Any> KMapper(noinline parameterNameConverter: ((String) -> String)? = null) =
+inline fun <reified T : Any> KMapper(): Normal<T> = Normal(T::class)
+
+inline fun <reified T : Any> KMapper(noinline parameterNameConverter: ((String) -> String)): Normal<T> =
     Normal(T::class, parameterNameConverter)
 
-inline fun <reified T : Any> PlainKMapper(noinline parameterNameConverter: ((String) -> String)? = null) =
+inline fun <reified T : Any> PlainKMapper(): Plain<T> = Plain(T::class)
+
+inline fun <reified T : Any> PlainKMapper(noinline parameterNameConverter: ((String) -> String)): Plain<T> =
     Plain(T::class, parameterNameConverter)

--- a/src/main/kotlin/com/mapk/kmapper/DummyConstructor.kt
+++ b/src/main/kotlin/com/mapk/kmapper/DummyConstructor.kt
@@ -1,0 +1,23 @@
+@file:Suppress("FunctionName")
+
+package com.mapk.kmapper
+
+import com.mapk.kmapper.BoundKMapper as Bound
+import com.mapk.kmapper.KMapper as Normal
+import com.mapk.kmapper.PlainKMapper as Plain
+import kotlin.reflect.KFunction
+
+inline fun <reified S : Any, reified D : Any> BoundKMapper(
+    noinline parameterNameConverter: ((String) -> String)? = null
+) = Bound(D::class, S::class, parameterNameConverter)
+
+inline fun <reified S : Any, D : Any> BoundKMapper(
+    function: KFunction<D>,
+    noinline parameterNameConverter: ((String) -> String)? = null
+) = Bound(function, S::class, parameterNameConverter)
+
+inline fun <reified T : Any> KMapper(noinline parameterNameConverter: ((String) -> String)? = null) =
+    Normal(T::class, parameterNameConverter)
+
+inline fun <reified T : Any> PlainKMapper(noinline parameterNameConverter: ((String) -> String)? = null) =
+    Plain(T::class, parameterNameConverter)

--- a/src/test/kotlin/com/mapk/kmapper/ConverterKMapperTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ConverterKMapperTest.kt
@@ -37,7 +37,7 @@ class ConverterKMapperTest {
         @Test
         @DisplayName("コンストラクターでのコンバートテスト")
         fun constructorConverterTest() {
-            val mapper = KMapper(ConstructorConverterDst::class)
+            val mapper = KMapper(::ConstructorConverterDst)
             val result = mapper.map(mapOf("argument" to 1))
 
             assertEquals(ConstructorConverter(1), result.argument)
@@ -55,7 +55,7 @@ class ConverterKMapperTest {
         @Test
         @DisplayName("スタティックメソッドに定義したコンバータでのコンバートテスト")
         fun staticMethodConverterTest() {
-            val mapper = KMapper(StaticMethodConverterDst::class)
+            val mapper = KMapper<StaticMethodConverterDst>()
             val result = mapper.map(mapOf("argument" to "1,2,3"))
 
             assertTrue(intArrayOf(1, 2, 3) contentEquals result.argument.arg)
@@ -77,7 +77,7 @@ class ConverterKMapperTest {
         @Test
         @DisplayName("コンパニオンオブジェクトに定義したコンバータでのコンバートテスト")
         fun companionConverterTest() {
-            val mapper = PlainKMapper(CompanionConverterDst::class)
+            val mapper = PlainKMapper(::CompanionConverterDst)
             val result = mapper.map(mapOf("argument" to "arg"))
 
             assertEquals("arg", result.argument.arg)
@@ -86,7 +86,7 @@ class ConverterKMapperTest {
         @Test
         @DisplayName("スタティックメソッドに定義したコンバータでのコンバートテスト")
         fun staticMethodConverterTest() {
-            val mapper = PlainKMapper(StaticMethodConverterDst::class)
+            val mapper = PlainKMapper<StaticMethodConverterDst>()
             val result = mapper.map(mapOf("argument" to "1,2,3"))
 
             assertTrue(intArrayOf(1, 2, 3) contentEquals result.argument.arg)
@@ -108,7 +108,7 @@ class ConverterKMapperTest {
         @Test
         @DisplayName("コンパニオンオブジェクトに定義したコンバータでのコンバートテスト")
         fun companionConverterTest() {
-            val mapper = BoundKMapper(::CompanionConverterDst, BoundCompanionConverterSrc::class)
+            val mapper: BoundKMapper<BoundCompanionConverterSrc, CompanionConverterDst> = BoundKMapper()
             val result = mapper.map(BoundCompanionConverterSrc("arg"))
 
             assertEquals("arg", result.argument.arg)
@@ -117,7 +117,7 @@ class ConverterKMapperTest {
         @Test
         @DisplayName("スタティックメソッドに定義したコンバータでのコンバートテスト")
         fun staticMethodConverterTest() {
-            val mapper = BoundKMapper(::StaticMethodConverterDst, BoundStaticMethodConverterSrc::class)
+            val mapper = BoundKMapper(StaticMethodConverterDst::class, BoundStaticMethodConverterSrc::class)
             val result = mapper.map(BoundStaticMethodConverterSrc("1,2,3"))
 
             assertTrue(intArrayOf(1, 2, 3) contentEquals result.argument.arg)

--- a/src/test/kotlin/com/mapk/kmapper/ParameterNameConverterTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ParameterNameConverterTest.kt
@@ -20,7 +20,7 @@ class ParameterNameConverterTest {
             val expected = "snakeCase"
             val src = mapOf("camel_case" to expected)
 
-            val mapper = KMapper(CamelCaseDst::class) {
+            val mapper = KMapper<CamelCaseDst> {
                 CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it)
             }
             val result = mapper.map(src)
@@ -38,7 +38,7 @@ class ParameterNameConverterTest {
             val expected = "snakeCase"
             val src = mapOf("camel_case" to expected)
 
-            val mapper = PlainKMapper(CamelCaseDst::class) {
+            val mapper = PlainKMapper<CamelCaseDst> {
                 CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it)
             }
             val result = mapper.map(src)
@@ -54,7 +54,7 @@ class ParameterNameConverterTest {
         @DisplayName("スネークケースsrc -> キャメルケースdst")
         fun test() {
 
-            val mapper = BoundKMapper(::CamelCaseDst, BoundSrc::class) {
+            val mapper = BoundKMapper<BoundSrc, CamelCaseDst> {
                 CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it)
             }
             val result = mapper.map(BoundSrc("snakeCase"))


### PR DESCRIPTION
特にクラスから初期化する場合にダミーコンストラクタを用いた記法が有効だったため、全般にダミーコンストラクタを追加した。