### PR TITLE
Fix converter nullability.

### DIFF
--- a/src/main/kotlin/com/mapk/conversion/KConvert.kt
+++ b/src/main/kotlin/com/mapk/conversion/KConvert.kt
@@ -9,5 +9,5 @@ annotation class KConvertBy(val converters: Array<KClass<out AbstractKConverter<
 
 abstract class AbstractKConverter<A : Annotation, S : Any, D : Any>(protected val annotation: A) {
     abstract val srcClass: KClass<S>
-    abstract fun convert(source: S?): D?
+    abstract fun convert(source: S): D?
 }

--- a/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/kmapper/BoundParameterForMap.kt
@@ -29,7 +29,7 @@ internal sealed class BoundParameterForMap<S> {
         override val propertyGetter: Method,
         private val converter: KFunction<*>
     ) : BoundParameterForMap<S>() {
-        override fun map(src: S): Any? = converter.call(propertyGetter.invoke(src))
+        override fun map(src: S): Any? = propertyGetter.invoke(src)?.let { converter.call(it) }
     }
 
     internal class UseKMapper<S : Any>(

--- a/src/test/kotlin/com/mapk/kmapper/ConversionTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ConversionTest.kt
@@ -8,8 +8,11 @@ import java.math.BigInteger
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.ValueSource
@@ -56,9 +59,10 @@ class ConversionTest {
         override fun convert(source: Number): Number? = source.let(converter)
     }
 
-    data class Dst(@ToNumber(BigDecimal::class) val number: BigDecimal)
+    data class Dst(@ToNumber(BigDecimal::class) val number: BigDecimal?)
     data class NumberSrc(val number: Number)
     data class StringSrc(val number: String)
+    object NullSrc { val number: Number? = null }
 
     enum class NumberSource(val values: Array<Number>) {
         Doubles(arrayOf(1.0, -2.0, 3.5)),
@@ -89,6 +93,15 @@ class ConversionTest {
             val actual = KMapper(::Dst).map(StringSrc(str))
             assertEquals(0, BigDecimal(str).compareTo(actual.number))
         }
+
+        @Test
+        @DisplayName("nullを入れた際に変換処理に入らないことのテスト")
+        fun fromNull() {
+            assertDoesNotThrow {
+                val actual = KMapper(::Dst).map(NullSrc)
+                assertNull(actual.number)
+            }
+        }
     }
 
     @Nested
@@ -111,6 +124,15 @@ class ConversionTest {
             val actual = PlainKMapper(::Dst).map(StringSrc(str))
             assertEquals(0, BigDecimal(str).compareTo(actual.number))
         }
+
+        @Test
+        @DisplayName("nullを入れた際に変換処理に入らないことのテスト")
+        fun fromNull() {
+            assertDoesNotThrow {
+                val actual = PlainKMapper(::Dst).map(NullSrc)
+                assertNull(actual.number)
+            }
+        }
     }
 
     @Nested
@@ -132,6 +154,15 @@ class ConversionTest {
         fun fromString(str: String) {
             val actual = BoundKMapper<StringSrc, Dst>().map(StringSrc(str))
             assertEquals(0, BigDecimal(str).compareTo(actual.number))
+        }
+
+        @Test
+        @DisplayName("nullを入れた際に変換処理に入らないことのテスト")
+        fun fromNull() {
+            assertDoesNotThrow {
+                val actual = BoundKMapper<NullSrc, Dst>(::Dst).map(NullSrc)
+                assertNull(actual.number)
+            }
         }
     }
 }

--- a/src/test/kotlin/com/mapk/kmapper/ConversionTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ConversionTest.kt
@@ -76,12 +76,14 @@ class ConversionTest {
     @Nested
     @DisplayName("KMapper")
     inner class KMapperTest {
+        private val mapper = KMapper(::Dst)
+
         @ParameterizedTest
         @EnumSource(NumberSource::class)
         @DisplayName("Numberソース")
         fun fromNumber(numbers: NumberSource) {
             numbers.values.forEach {
-                val actual = KMapper(::Dst).map(NumberSrc(it))
+                val actual = mapper.map(NumberSrc(it))
                 assertEquals(0, BigDecimal.valueOf(it.toDouble()).compareTo(actual.number))
             }
         }
@@ -90,7 +92,7 @@ class ConversionTest {
         @ValueSource(strings = ["100", "2.0", "-500"])
         @DisplayName("Stringソース")
         fun fromString(str: String) {
-            val actual = KMapper(::Dst).map(StringSrc(str))
+            val actual = mapper.map(StringSrc(str))
             assertEquals(0, BigDecimal(str).compareTo(actual.number))
         }
 
@@ -98,7 +100,7 @@ class ConversionTest {
         @DisplayName("nullを入れた際に変換処理に入らないことのテスト")
         fun fromNull() {
             assertDoesNotThrow {
-                val actual = KMapper(::Dst).map(NullSrc)
+                val actual = mapper.map(NullSrc)
                 assertNull(actual.number)
             }
         }
@@ -107,12 +109,14 @@ class ConversionTest {
     @Nested
     @DisplayName("PlainKMapper")
     inner class PlainKMapperTest {
+        private val mapper = PlainKMapper(::Dst)
+
         @ParameterizedTest
         @EnumSource(NumberSource::class)
         @DisplayName("Numberソース")
         fun fromNumber(numbers: NumberSource) {
             numbers.values.forEach {
-                val actual = PlainKMapper(::Dst).map(NumberSrc(it))
+                val actual = mapper.map(NumberSrc(it))
                 assertEquals(0, BigDecimal.valueOf(it.toDouble()).compareTo(actual.number))
             }
         }
@@ -121,7 +125,7 @@ class ConversionTest {
         @ValueSource(strings = ["100", "2.0", "-500"])
         @DisplayName("Stringソース")
         fun fromString(str: String) {
-            val actual = PlainKMapper(::Dst).map(StringSrc(str))
+            val actual = mapper.map(StringSrc(str))
             assertEquals(0, BigDecimal(str).compareTo(actual.number))
         }
 
@@ -129,7 +133,7 @@ class ConversionTest {
         @DisplayName("nullを入れた際に変換処理に入らないことのテスト")
         fun fromNull() {
             assertDoesNotThrow {
-                val actual = PlainKMapper(::Dst).map(NullSrc)
+                val actual = mapper.map(NullSrc)
                 assertNull(actual.number)
             }
         }

--- a/src/test/kotlin/com/mapk/kmapper/ConversionTest.kt
+++ b/src/test/kotlin/com/mapk/kmapper/ConversionTest.kt
@@ -36,7 +36,7 @@ class ConversionTest {
         }
 
         override val srcClass = String::class
-        override fun convert(source: String?): Number? = source?.let(converter)
+        override fun convert(source: String): Number? = source.let(converter)
     }
 
     class FromNumber(annotation: ToNumber) : AbstractKConverter<ToNumber, Number, Number>(annotation) {
@@ -53,7 +53,7 @@ class ConversionTest {
         }
 
         override val srcClass = Number::class
-        override fun convert(source: Number?): Number? = source?.let(converter)
+        override fun convert(source: Number): Number? = source.let(converter)
     }
 
     data class Dst(@ToNumber(BigDecimal::class) val number: BigDecimal)


### PR DESCRIPTION
# 変更の前提
## ProjectMapKにおける変換処理の方針について
`ProjectMapK`内では、変換処理の引数を`non-null`で扱う。
理由は、変換処理は共通で使い回されるものである一方、入力が`null`だった場合に設定する値というのは関数ごとに決定されるべきと考えられるためである。

### 補足: 「nullならデフォルト値」の実現方法
「`null`ならデフォルト値」の実現は以下2つの方法が考えられる。

1. 関数側で`null`時の取り扱いを記述する
2. `KParameterRequireNonNull`アノテーションとデフォルト引数を組み合わせる

# 変更内容
## 修正
`BoundKMapper`で、`null`でも変換処理を動かしていた（= 他のマッピングクラスと挙動が異なっていた）不具合の修正を行った。

## 破壊的変更
変換処理は値が`null`では発生しないため、`AbstractKConverter`の`convert`関数のパラメータを`non-null`要求に修正した。

## その他
変更に合わせテストの修正を行い、テストパターンも追加を行った。